### PR TITLE
feat(ai): ai:complete IPC stub end-to-end (Sprint 0, S0-2)

### DIFF
--- a/apps/desktop/electron/ai/client.test.ts
+++ b/apps/desktop/electron/ai/client.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { hasApiKey, runAiComplete } from "./client";
+
+describe("ai/client (S0-2 stub)", () => {
+  const original = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = original;
+    }
+  });
+
+  it("hasApiKey reflects the env var (blank counts as missing)", () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    expect(hasApiKey()).toBe(false);
+
+    process.env.ANTHROPIC_API_KEY = "   ";
+    expect(hasApiKey()).toBe(false);
+
+    process.env.ANTHROPIC_API_KEY = "sk-test-123";
+    expect(hasApiKey()).toBe(true);
+  });
+
+  it("runAiComplete echoes a canned assistant text block", async () => {
+    const result = await runAiComplete({
+      requestId: "req-1",
+      model: "claude-opus-4-8",
+      system: "you are a test",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(result.requestId).toBe("req-1");
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.content[0].type).toBe("text");
+    expect(String(result.content[0].text)).toContain("stub");
+  });
+});

--- a/apps/desktop/electron/ai/client.ts
+++ b/apps/desktop/electron/ai/client.ts
@@ -1,0 +1,76 @@
+/**
+ * electron/ai/client.ts — main-process Claude boundary (Sprint 0, task S0-2).
+ *
+ * S0-2 ships a STUB: no network call. `runAiComplete` echoes a canned assistant
+ * message so Person B can build the renderer agent loop against a real IPC
+ * round-trip today. S1-2 replaces the body with the actual `@anthropic-ai/sdk`
+ * call and maps the wire types below to/from SDK types.
+ *
+ * SECURITY: the Anthropic API key lives ONLY in this process. It is never
+ * returned to or referenced by the renderer.
+ *
+ * The wire types here mirror the IPC section of `src/lib/ai/contract.ts`. Keep
+ * them in sync — see docs/ai-team-log.md decision D1 (renderer stays SDK-free;
+ * main owns the SDK and the mapping).
+ */
+
+export type AiRole = "user" | "assistant";
+
+export interface AiContentBlockWire {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface AiMessageWire {
+  role: AiRole;
+  content: string | AiContentBlockWire[];
+}
+
+export interface AiCompleteRequestWire {
+  requestId: string;
+  model: string;
+  system: string;
+  messages: AiMessageWire[];
+  tools?: unknown[];
+  maxTokens?: number;
+  stream?: boolean;
+  /** Opus-only; omitted for Haiku. */
+  effort?: "low" | "medium" | "high" | "max";
+}
+
+export interface AiCompleteResultWire {
+  requestId: string;
+  stopReason: string;
+  content: AiContentBlockWire[];
+  usage?: { inputTokens: number; outputTokens: number };
+}
+
+/** True when an Anthropic API key is configured in the main-process env. */
+export function hasApiKey(): boolean {
+  const key = process.env.ANTHROPIC_API_KEY;
+  return typeof key === "string" && key.trim().length > 0;
+}
+
+/**
+ * S0-2 STUB — returns a canned assistant text block, no network.
+ * Replaced by the real Anthropic tool-use call in S1-2.
+ */
+export async function runAiComplete(
+  request: AiCompleteRequestWire,
+): Promise<AiCompleteResultWire> {
+  const messageCount = Array.isArray(request?.messages)
+    ? request.messages.length
+    : 0;
+  const model = request?.model ?? "(unset)";
+
+  const text =
+    `🔌 ai:complete stub — received ${messageCount} message(s) for model ` +
+    `"${model}". The real Anthropic call lands in S1-2.`;
+
+  return {
+    requestId: request?.requestId ?? "",
+    stopReason: "end_turn",
+    content: [{ type: "text", text }],
+    usage: { inputTokens: 0, outputTokens: 0 },
+  };
+}

--- a/apps/desktop/electron/electron-env.d.ts
+++ b/apps/desktop/electron/electron-env.d.ts
@@ -189,6 +189,25 @@ interface RendererNativeVideoMetadataProbe {
 
 interface Window {
 	electronAPI: {
+		/** AI (Quiro Director) — mirrors src/lib/ai/contract.ts; keep in sync (S0-2). */
+		ai: {
+			complete: (request: {
+				requestId: string;
+				model: string;
+				system: string;
+				messages: Array<{ role: "user" | "assistant"; content: string | unknown[] }>;
+				tools?: unknown[];
+				maxTokens?: number;
+				stream?: boolean;
+				effort?: "low" | "medium" | "high" | "max";
+			}) => Promise<{
+				requestId: string;
+				stopReason: string;
+				content: Array<{ type: string; [key: string]: unknown }>;
+				usage?: { inputTokens: number; outputTokens: number };
+			}>;
+			getKeyStatus: () => Promise<{ hasKey: boolean }>;
+		};
 		hudOverlaySetIgnoreMouse: (ignore: boolean) => void;
 		hudOverlayDrag: (phase: "start" | "move" | "end", screenX: number, screenY: number) => void;
 		hudOverlayHide: () => void;

--- a/apps/desktop/electron/ipc/handlers.ts
+++ b/apps/desktop/electron/ipc/handlers.ts
@@ -8,6 +8,7 @@ import { registerRecordingHandlers } from "./register/recording";
 import { registerRecordingStreamHandlers } from "./register/recording-stream";
 import { registerSettingsHandlers } from "./register/settings";
 import { registerSourceHandlers } from "./register/sources";
+import { registerAiHandlers } from "./register/ai";
 import { registerPerfHandlers } from "../ipc/perf";
 import {
   selectedSource,
@@ -74,4 +75,5 @@ export function registerIpcHandlers(
   registerProjectHandlers();
   registerSettingsHandlers();
   registerPerfHandlers();
+  registerAiHandlers();
 }

--- a/apps/desktop/electron/ipc/register/ai.ts
+++ b/apps/desktop/electron/ipc/register/ai.ts
@@ -1,0 +1,39 @@
+import { ipcMain } from "electron";
+import {
+  hasApiKey,
+  runAiComplete,
+  type AiCompleteRequestWire,
+} from "../../ai/client";
+
+/**
+ * AI (Quiro Director) IPC — Sprint 0, task S0-2.
+ *
+ * Channel names mirror `AI_IPC` in `src/lib/ai/contract.ts`. Keep in sync with
+ * both `electron-env.d.ts` files and `preload.ts`.
+ */
+const AI_COMPLETE = "ai:complete";
+const AI_GET_KEY_STATUS = "ai:get-key-status";
+
+export function registerAiHandlers() {
+  ipcMain.handle(
+    AI_COMPLETE,
+    async (_event, request: AiCompleteRequestWire) => {
+      try {
+        return await runAiComplete(request);
+      } catch (error) {
+        console.error("ai:complete failed:", error);
+        return {
+          requestId: request?.requestId ?? "",
+          stopReason: "error",
+          content: [
+            { type: "text", text: `ai:complete failed: ${String(error)}` },
+          ],
+        };
+      }
+    },
+  );
+
+  ipcMain.handle(AI_GET_KEY_STATUS, async () => {
+    return { hasKey: hasApiKey() };
+  });
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -77,6 +77,12 @@ function settleNativeVideoExportPendingRequests(
 }
 
 contextBridge.exposeInMainWorld("electronAPI", {
+  // AI (Quiro Director) — Sprint 0, S0-2. Channels mirror src/lib/ai/contract.ts.
+  ai: {
+    complete: (request: unknown) =>
+      ipcRenderer.invoke("ai:complete", request),
+    getKeyStatus: () => ipcRenderer.invoke("ai:get-key-status"),
+  },
   hudOverlaySetIgnoreMouse: (ignore: boolean) => {
     ipcRenderer.send("hud-overlay-set-ignore-mouse", ignore);
   },

--- a/apps/desktop/src/types/electron-env.d.ts
+++ b/apps/desktop/src/types/electron-env.d.ts
@@ -205,6 +205,25 @@ interface RendererNativeVideoMetadataProbe {
 
 interface Window {
   electronAPI: {
+    /** AI (Quiro Director) — mirrors src/lib/ai/contract.ts; keep in sync (S0-2). */
+    ai: {
+      complete: (request: {
+        requestId: string;
+        model: string;
+        system: string;
+        messages: Array<{ role: 'user' | 'assistant'; content: string | unknown[] }>;
+        tools?: unknown[];
+        maxTokens?: number;
+        stream?: boolean;
+        effort?: 'low' | 'medium' | 'high' | 'max';
+      }) => Promise<{
+        requestId: string;
+        stopReason: string;
+        content: Array<{ type: string; [key: string]: unknown }>;
+        usage?: { inputTokens: number; outputTokens: number };
+      }>;
+      getKeyStatus: () => Promise<{ hasKey: boolean }>;
+    };
     hudOverlaySetIgnoreMouse: (ignore: boolean) => void;
     hudOverlayDrag: (
       phase: 'start' | 'move' | 'end',

--- a/docs/ai-team-log.md
+++ b/docs/ai-team-log.md
@@ -20,8 +20,8 @@
 | Task | Owner | Status | Notes |
 |---|---|---|---|
 | **S0-1** Shared contract (`contract.ts`) | A+B | ✅ done | Typechecks + lints clean. **Review & confirm, B.** |
-| **S0-2** `ai:complete` IPC stub + both `d.ts` | A | ⬜ next | Ship the *stub* first so B can build the agent loop. |
-| **S0-3** API key config + "missing key" state | A | ⬜ todo | |
+| **S0-2** `ai:complete` IPC stub + both `d.ts` | A | ✅ done | Stub live; `window.electronAPI.ai.complete(...)` round-trips. **@B unblocked.** |
+| **S0-3** API key config + "missing key" state | A | ⬜ next | `hasApiKey()` already reads env; S0-3 formalizes `.env` + UI state. |
 | **S0-4** Empty ChatPanel + stub `EditorActions` | B | ⬜ todo | Implement `EditorActions` against the contract. |
 
 _Update this board as things move._
@@ -50,6 +50,33 @@ _Update this board as things move._
 ---
 
 ## 🧾 Handoff log
+
+### 2026-06-19 — S0-2 `ai:complete` IPC stub landed ✅  `@B you're unblocked`
+**From:** A (paired w/ Claude) · **Re:** `electron/ai/`, `electron/ipc/register/ai.ts`, `preload.ts`, both `electron-env.d.ts`
+
+The full AI IPC bridge is wired end-to-end (as a **stub** — no network yet). The renderer can now call the bridge and get a real round-trip.
+
+**What's callable from the renderer right now:**
+- `window.electronAPI.ai.complete(request)` → resolves an `AiCompleteResult`-shaped object. Today it echoes a canned assistant text block (`"🔌 ai:complete stub …"`); the real Anthropic tool-use call replaces the body in **S1-2** — the IPC shape won't change.
+- `window.electronAPI.ai.getKeyStatus()` → `{ hasKey: boolean }` (reads `ANTHROPIC_API_KEY` in main).
+
+**Files (all touched per the CLAUDE.md IPC checklist):**
+- `electron/ai/client.ts` — `runAiComplete()` (stub) + `hasApiKey()`; **the API key lives only here.**
+- `electron/ipc/register/ai.ts` — `registerAiHandlers()` for `ai:complete` + `ai:get-key-status`.
+- `electron/ipc/handlers.ts` — calls `registerAiHandlers()`.
+- `electron/preload.ts` — exposes `electronAPI.ai`.
+- `electron/electron-env.d.ts` **and** `src/types/electron-env.d.ts` — typed (kept in sync).
+- `electron/ai/client.test.ts` — 2 passing unit tests.
+
+**Verified:** `tsc --noEmit` ✅ · `eslint --max-warnings 0` ✅ · `vitest` ✅ (2/2).
+
+**@B — what you can build now (S0-4 + S1-3):** wire your agent runner against `window.electronAPI.ai.complete`. Build the loop, the message array, and tool round-trips against the stub today; when I land the real call (S1-2) it just starts returning real `tool_use` blocks. The IPC types are in both `d.ts` files and mirror the contract.
+
+**Tip:** for renderer-side type safety, wrap the bridge in a tiny typed helper that casts to the contract's `AiCompleteRequest`/`AiCompleteResult` (the `d.ts` types are intentionally structural). I can add that helper in S1-2 if you want — say so here.
+
+**Next for me (A):** S0-3 — formalize the API key (`.env.example` + load + a friendly "add your key" state). `hasApiKey()` already exists, so this is mostly UX + config.
+
+---
 
 ### 2026-06-19 — S0-1 contract landed ✅  `@B please review`
 **From:** A (paired w/ Claude) · **Re:** `apps/desktop/src/lib/ai/contract.ts`


### PR DESCRIPTION
## What

Implements **S0-2** from [ai-sprint-plan.md](docs/ai-sprint-plan.md) — wires the `ai:complete` IPC bridge end-to-end through every layer, as a **stub** (no network call yet). This lets Person B build the renderer agent loop against a real IPC round-trip before the live model lands in S1-2.

Builds on the shared contract from #5 (already merged).

**Renderer can now call:**
- `window.electronAPI.ai.complete(request)` → resolves an `AiCompleteResult`-shaped object. Today it echoes a canned assistant text block; **S1-2 swaps in the real `@anthropic-ai/sdk` tool-use call — the IPC shape will not change.**
- `window.electronAPI.ai.getKeyStatus()` → `{ hasKey: boolean }`.

**Files (the full CLAUDE.md IPC checklist):**
| File | What |
| --- | --- |
| `electron/ai/client.ts` | `runAiComplete()` stub + `hasApiKey()` — **the Anthropic API key lives only in the main process** |
| `electron/ipc/register/ai.ts` | `registerAiHandlers()` for `ai:complete` + `ai:get-key-status` |
| `electron/ipc/handlers.ts` | calls `registerAiHandlers()` in the hub |
| `electron/preload.ts` | exposes `electronAPI.ai` |
| `electron/electron-env.d.ts` + `src/types/electron-env.d.ts` | typed in **both**, kept in sync |
| `electron/ai/client.test.ts` | 2 passing unit tests |
| `docs/ai-team-log.md` | S0-2 handoff entry + status-board update |

## Why

Unblocks Person B (agent loop, S1-3) immediately: they can build the message array and tool round-trips against a real bridge today. The stub's response shape is final, so swapping in the real model later is a body-only change in `runAiComplete`.

## Reviewer notes

- **Stub only — no live model call, no key required to run.**
- Per decision **D1** (see team log): the renderer stays SDK-free; the main process owns `@anthropic-ai/sdk` and maps the wire types ↔ SDK types. Wire types in `client.ts` mirror the IPC section of `src/lib/ai/contract.ts`.
- **Verified:** `tsc --noEmit` ✅ · `eslint --max-warnings 0` ✅ · `vitest` ✅ (2/2).
- Both `electron-env.d.ts` files updated together (electron = tabs/double-quotes, src = spaces/single-quotes, matching each file's existing style).
- Local `.claude/settings.local.json` intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)