### PR TITLE
docs(claude): record HUD topmost guard + CI/release gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ npm run build          # full packaged build (electron-builder → release/<vers
 
 Unit tests are colocated `*.test.ts` next to sources. Feature tests live in `apps/desktop/tests/feature/` and generate fixtures under `tests/fixtures/generated/`.
 
-Native Windows helpers (cursor monitor, WGC capture, GPU export, whisper runtime) have prebuilt binaries **committed** at `electron/native/bin/win32-x64/`. Only rebuild them (`npm run build:platform-native-helpers`, needs VS2022 + CMake) if you changed their C++ sources; otherwise leave the binaries alone.
+Native Windows helpers (cursor monitor, WGC capture, GPU export, hud-topmost-guard, whisper runtime) have prebuilt binaries **committed** at `electron/native/bin/win32-x64/`. Only rebuild them (`npm run build:platform-native-helpers`, needs VS2022 + CMake) if you changed their C++ sources; otherwise leave the binaries alone. Each has a build script under `scripts/build-*.mjs` that also refreshes `electron/native/bin/win32-x64/helpers-manifest.json` (sha256 + source fingerprint) — commit the rebuilt binary and the manifest together; if only `updatedAt` timestamps changed, revert the manifest (churn).
 
 ## Architecture
 
@@ -42,6 +42,7 @@ Native Windows helpers (cursor monitor, WGC capture, GPU export, whisper runtime
 - `electron/` — main process. IPC handlers live in `electron/ipc/` and are registered via `electron/ipc/register/*`; `electron/ipc/handlers.ts` is the hub. Media files are served to the renderer over local HTTP servers (`electron/utils/mediaServer.ts`, `electron/renderer-server.ts`), not `file://`.
 - `electron/preload.ts` exposes the API as `window.electronAPI`. Its type lives in **two places that must stay in sync**: `electron/electron-env.d.ts` and `src/types/electron-env.d.ts`. Adding an IPC channel means touching: handler, register file, preload, both d.ts files.
 - `src/` — renderer. Two windows: launch/HUD (`src/components/launch/`) and the editor (`src/components/editor/`).
+- The launch/HUD is a transparent `alwaysOnTop` window. On Windows `alwaysOnTop` is only best-effort (the OS reorders within the single topmost band, and activating another window via Alt+Tab/taskbar can leave it underneath), so `electron/window.ts` spawns a native `hud-topmost-guard` helper with the HUD's HWND. The guard re-asserts `HWND_TOPMOST` on `EVENT_SYSTEM_FOREGROUND` (via `SetWinEventHook`) using `SetWindowPos(..., SWP_NOACTIVATE|NOMOVE|NOSIZE)` **without** `SWP_SHOWWINDOW` — reclaiming top instantly (no flash) without corrupting the `WS_EX_TRANSPARENT` mouse pass-through. Don't regress this to `moveTop()` polling (too slow/weak, and it was suppressed during interaction) or to a `setAlwaysOnTop(false→true)` toggle (flashes + breaks pass-through on Win11). It falls back to a JS `moveTop()` poll only if the helper binary is missing.
 
 ### The editor (where most complexity lives)
 
@@ -68,3 +69,16 @@ The editor had severe playback stutter caused by React re-rendering the whole `E
 5. High-frequency input is coalesced: the `Scrubber` slider and timeline playhead scrub commit at most once per animation frame; zoom-focus dragging in `playback.tsx` updates the overlay locally and commits region state only on pointer-up.
 
 Debug tooling (dev-only, safe to leave in): `src/lib/playbackSessionDebug.ts` logs per-playback-session stats (presented-frame gaps, decoder drops, long tasks, per-phase ticker timing, `react:*` Profiler probe costs) to the console; toggle with `window.__PLAYBACK_DEBUG = false/true`. `PerfOverlay` (Ctrl+Shift+P) shows live FPS/CPU/IPC. After any change to playback, preview rendering, or window.tsx state flow, play a clip and check the session summary — `stalls ≥80ms` should stay at none and `react:settings-panel` should stay near zero during playback.
+
+The preview Pixi ticker (`playback.tsx`) runs every frame; keep its idle cost low. The per-frame extension effects-canvas pass (clear + `hookParams` build) is gated behind `extensionHost.hasAnyRenderHooks() || hasCursorEffects()` — don't move work out of that guard, and don't reintroduce per-frame writes that already persist (e.g. `preservesPitch`, or `playbackRate` when unchanged) in `videoEventHandlers.ts`.
+
+## CI & release
+
+Two workflows: `.github/workflows/test.yml` (Windows + macOS matrix on every PR/push — desktop `test:ci` = typecheck + vitest, plus `@quiro/web` typecheck) and `.github/workflows/release.yml`.
+
+**Releasing** is triggered by pushing a `v*` tag (e.g. `v1.2.0`). `prepare-release` fails unless the tag version equals `apps/desktop/package.json` version (the only versioned workspace), so bump that, land it on `main`, then tag `main`. The pipeline builds signed Windows + notarized macOS installers, checksums them, and uploads to the GitHub Release, which shipped clients auto-update from (~90 min). `release.yml` runs desktop unit tests on the Windows build job but **not** the web typecheck, so a red web typecheck in `test.yml` does not block a release build.
+
+Known CI gotchas — these fail **only in CI** (clean `npm ci`), pass in local dev, and are already fixed; don't reintroduce them:
+
+- **macOS Electron-install race.** `test.yml` installs with `npm ci --ignore-scripts`, so Electron's binary isn't extracted at install. vitest runs test files in parallel, so the first tests to `import "electron"` (`electron/ai/*`) race to extract into `node_modules/electron/dist` and collide creating the macOS-only `Electron Framework` symlink → `EEXIST` / "Electron failed to install correctly". Fixed by a serial `node node_modules/electron/install.js` step before the tests — **keep it**. Windows has no such symlink, so it never broke there.
+- **`apps/web` two `@types/react` copies.** Web uses React 19 types while the root hoists `@types/react@18` for desktop (see repo-layout note). Under clean install, `motion` and the global JSX namespace resolve the root v18 while web source uses v19, so `@quiro/web` typecheck fails with `Provider cannot be used as a JSX component` / `ReactNode not assignable to ReactNode`. `motion` doesn't declare `@types/react`, so npm `overrides` can't fix it — it's a TS resolution issue. Fixed by pinning `react`/`react-dom` type resolution to the web copy via `paths` in `apps/web/tsconfig.json` — **keep those entries**. Next force-aliases react at runtime, so `next build` is unaffected. To reproduce locally you must do a clean `npm ci` (a stale local `node_modules` dedupes and hides it).


### PR DESCRIPTION
Documents the context from the v1.2.0 release work in `CLAUDE.md` so future changes don't regress the fixes or re-hit the same CI walls.

Added:
- **HUD launch-overlay always-on-top guard** — how `hud-topmost-guard` works and why not to revert it to `moveTop()` polling or a `setAlwaysOnTop(false→true)` toggle.
- **Native-helper manifest** — build scripts refresh `helpers-manifest.json`; revert timestamp-only churn.
- **Preview ticker idle cost** — the extension effects-canvas gate and "no redundant per-frame media writes" rule.
- **CI & release section** — the `v*`-tag release flow (tag version must match `apps/desktop/package.json`, tag `main` after merge; release build doesn't run the web typecheck), plus the two CI-only failures we fixed: the macOS Electron-install parallel-extract race and the `apps/web` dual `@types/react` (v18/v19) resolution.

Docs-only; no code changes.