### PR TITLE
Phase 1: camera motion quality — easing, instant zoom, drift, presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@ The editor had severe playback stutter caused by React re-rendering the whole `E
 
 Debug tooling (dev-only, safe to leave in): `src/lib/playbackSessionDebug.ts` logs per-playback-session stats (presented-frame gaps, decoder drops, long tasks, per-phase ticker timing, `react:*` Profiler probe costs) to the console; toggle with `window.__PLAYBACK_DEBUG = false/true`. `PerfOverlay` (Ctrl+Shift+P) shows live FPS/CPU/IPC. After any change to playback, preview rendering, or window.tsx state flow, play a clip and check the session summary — `stalls ≥80ms` should stay at none and `react:settings-panel` should stay near zero during playback.
 
+## CI & release
+
+Releasing is triggered by pushing a `v*` tag; `prepare-release` fails unless the tag matches `apps/desktop/package.json`'s version.
+
+**Canonical release path:** from `apps/desktop`, run `npm run release:patch` / `release:minor` / `release:major`. It bumps the version, syncs the root lockfile (`npm install --package-lock-only` at repo root — easy to skip by hand, and it has drifted before), commits, tags `main` (annotated), pushes, and creates the GitHub Release. If releasing by hand instead, you must run that lockfile sync yourself.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,11 @@ The preview Pixi ticker (`playback.tsx`) runs every frame; keep its idle cost lo
 
 Two workflows: `.github/workflows/test.yml` (Windows + macOS matrix on every PR/push — desktop `test:ci` = typecheck + vitest, plus `@quiro/web` typecheck) and `.github/workflows/release.yml`.
 
-**Releasing** is triggered by pushing a `v*` tag (e.g. `v1.2.0`). `prepare-release` fails unless the tag version equals `apps/desktop/package.json` version (the only versioned workspace), so bump that, land it on `main`, then tag `main`. The pipeline builds signed Windows + notarized macOS installers, checksums them, and uploads to the GitHub Release, which shipped clients auto-update from (~90 min). `release.yml` runs desktop unit tests on the Windows build job but **not** the web typecheck, so a red web typecheck in `test.yml` does not block a release build.
+**Releasing** is triggered by pushing a `v*` tag (e.g. `v1.2.0`). `prepare-release` fails unless the tag version equals `apps/desktop/package.json` version (the only versioned workspace) — that's the constraint the release path below exists to satisfy. The pipeline builds signed Windows + notarized macOS installers, checksums them, and uploads to the GitHub Release, which shipped clients auto-update from (~90 min). `release.yml` runs desktop unit tests on the Windows build job but **not** the web typecheck, so a red web typecheck in `test.yml` does not block a release build.
+
+**Canonical release path:** from `apps/desktop`, run `npm run release:patch` / `release:minor` / `release:major`. It runs `test:ci`, bumps `apps/desktop/package.json`, **syncs the root lockfile** (`npm install --package-lock-only` at repo root — the step a manual release skips and that drifted twice, see #15), commits both as `chore(release): v<version>`, tags `main` with an **annotated** tag, pushes branch and tag, then creates the GitHub Release (`gh release create --verify-tag`). Flags: `--no-push`, `--no-github-release`, `--skip-tests`.
+
+If you must do it by hand — bump `apps/desktop/package.json`, land it on `main`, tag `main` — you **must** also run `npm install --package-lock-only` at the repo root before committing, or the root lockfile drifts from the workspace version again.
 
 Known CI gotchas — these fail **only in CI** (clean `npm ci`), pass in local dev, and are already fixed; don't reintroduce them:
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,7 +33,8 @@
     "build:cursor-monitor": "node scripts/build-cursor-monitor.mjs",
     "build:hud-topmost-guard": "node scripts/build-hud-topmost-guard.mjs",
     "generate:icons": "tsx scripts/generate-icon.ts",
-    "rename:exporter-files": "node scripts/rename-exporter-filenames.mjs"
+    "rename:exporter-files": "node scripts/rename-exporter-filenames.mjs",
+    "compare:camera-tuning": "tsx scripts/compare-camera-tuning.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.105.0",

--- a/apps/desktop/scripts/compare-camera-tuning.ts
+++ b/apps/desktop/scripts/compare-camera-tuning.ts
@@ -1,0 +1,327 @@
+/**
+ * Camera tuning comparison harness (dev-only, issue #21).
+ *
+ * Renders the same zoom regions twice — once under the current defaults, once
+ * under a candidate tuning — and writes a side-by-side HTML report of the
+ * resulting camera trajectories.
+ *
+ *   npm run compare:camera-tuning
+ *   npm run compare:camera-tuning -- --smoothness 0.8 --zoom-in-easing snappy
+ *
+ * What it compares, and why that is the right thing:
+ *
+ * The sweep (#29) tunes how the camera moves. That motion is fully determined
+ * by the same pure functions the export renderers call — findDominantRegion,
+ * computeZoomTransform, getZoomSpringConfig and stepSpringValue — so this
+ * drives exactly those, and plots the scale and pan the renderer would apply.
+ * It deliberately does not encode video: an MP4 would add a decode, a
+ * composite and an encode on top of the trajectory without changing it, and
+ * would need a real recording to run at all.
+ *
+ * Two traps this respects, both of which silently invalidate a comparison:
+ *
+ * 1. The camera spring only runs during playback. Scrubbing, seeking and
+ *    Classic Animation all snap to the projected transform, so a spring change
+ *    is invisible while scrubbing. Every frame here is stepped, never sampled.
+ * 2. Preview steps the spring on wall-clock delta, export on content time. The
+ *    solver is analytic but the target moves every frame, so the two are not
+ *    bit-identical. This steps on content time — export against export — and
+ *    reports the measured divergence separately.
+ */
+
+import { writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+	buildCameraMotionOptions,
+	findDominantRegion,
+} from "../src/components/editor/videoPlayback/zoomRegionUtils";
+import {
+	createSpringState,
+	getZoomSpringConfig,
+	stepSpringValue,
+} from "../src/components/editor/videoPlayback/motionSmoothing";
+import { computeZoomTransform } from "../src/components/editor/videoPlayback/zoomTransform";
+import {
+	DEFAULT_ZOOM_IN_DURATION_MS,
+	DEFAULT_ZOOM_OUT_DURATION_MS,
+	DEFAULT_ZOOM_SMOOTHNESS,
+	ZOOM_DEPTH_SCALES,
+	type ZoomRegion,
+	type ZoomTransitionEasing,
+} from "../src/types/editor";
+
+const FRAME_RATE = 60;
+const FRAME_MS = 1000 / FRAME_RATE;
+const STAGE = { width: 1920, height: 1080 };
+const BASE_MASK = { x: 0, y: 0, width: 1920, height: 1080 };
+
+interface Tuning {
+	label: string;
+	zoomSmoothness: number;
+	cameraSpringStiffnessMultiplier: number;
+	cameraSpringDampingMultiplier: number;
+	cameraSpringMassMultiplier: number;
+	zoomInDurationMs: number;
+	zoomOutDurationMs: number;
+	zoomInEasing: ZoomTransitionEasing;
+	zoomOutEasing: ZoomTransitionEasing;
+}
+
+const CURRENT: Tuning = {
+	label: "current defaults",
+	zoomSmoothness: DEFAULT_ZOOM_SMOOTHNESS,
+	cameraSpringStiffnessMultiplier: 1,
+	cameraSpringDampingMultiplier: 1.13,
+	cameraSpringMassMultiplier: 1.12,
+	zoomInDurationMs: DEFAULT_ZOOM_IN_DURATION_MS,
+	zoomOutDurationMs: DEFAULT_ZOOM_OUT_DURATION_MS,
+	zoomInEasing: "quiro",
+	zoomOutEasing: "quiro",
+};
+
+/**
+ * A deliberately ordinary demo shape: punch in, hold, pull out, then a second
+ * shallower zoom close behind it so chained motion is visible too.
+ */
+const REGIONS: ZoomRegion[] = [
+	{
+		id: "a",
+		startMs: 500,
+		endMs: 4000,
+		depth: 4,
+		focus: { cx: 0.32, cy: 0.4 },
+		mode: "manual",
+	},
+	{
+		id: "b",
+		startMs: 5000,
+		endMs: 8000,
+		depth: 2,
+		focus: { cx: 0.7, cy: 0.62 },
+		mode: "manual",
+	},
+];
+const DURATION_MS = 9000;
+
+interface Sample {
+	timeMs: number;
+	scale: number;
+	x: number;
+	y: number;
+}
+
+/** Steps the camera exactly as an export renderer does: fixed content-time delta. */
+function renderTrajectory(tuning: Tuning, deltas?: number[]): Sample[] {
+	const options = buildCameraMotionOptions({
+		connectZooms: true,
+		zoomInDurationMs: tuning.zoomInDurationMs,
+		zoomOutDurationMs: tuning.zoomOutDurationMs,
+		zoomInEasing: tuning.zoomInEasing,
+		zoomOutEasing: tuning.zoomOutEasing,
+	});
+	const config = getZoomSpringConfig(tuning.zoomSmoothness, {
+		stiffnessMultiplier: tuning.cameraSpringStiffnessMultiplier,
+		dampingMultiplier: tuning.cameraSpringDampingMultiplier,
+		massMultiplier: tuning.cameraSpringMassMultiplier,
+	});
+
+	const springScale = createSpringState(1);
+	const springX = createSpringState(0);
+	const springY = createSpringState(0);
+	const samples: Sample[] = [];
+
+	let timeMs = 0;
+	let frame = 0;
+	while (timeMs <= DURATION_MS) {
+		const { region, strength, blendedScale } = findDominantRegion(
+			REGIONS,
+			timeMs,
+			options,
+		);
+		const zoomScale =
+			region && strength > 0
+				? (blendedScale ?? ZOOM_DEPTH_SCALES[region.depth])
+				: 1;
+		const focus = region && strength > 0 ? region.focus : { cx: 0.5, cy: 0.5 };
+		const projected = computeZoomTransform({
+			stageSize: STAGE,
+			baseMask: BASE_MASK,
+			zoomScale,
+			zoomProgress: region && strength > 0 ? strength : 0,
+			focusX: focus.cx,
+			focusY: focus.cy,
+		});
+
+		const deltaMs = deltas ? deltas[frame % deltas.length] : FRAME_MS;
+		samples.push({
+			timeMs,
+			scale: stepSpringValue(springScale, projected.scale, deltaMs, config),
+			x: stepSpringValue(springX, projected.x, deltaMs, config),
+			y: stepSpringValue(springY, projected.y, deltaMs, config),
+		});
+
+		timeMs += FRAME_MS;
+		frame += 1;
+	}
+
+	return samples;
+}
+
+/**
+ * How far a variable-rate preview drifts from a fixed-rate export.
+ *
+ * Jitter pattern is a plausible dropped/long-frame mix rather than a worst
+ * case; the point is to know the order of magnitude, not to bound it.
+ */
+function measurePreviewExportDivergence(tuning: Tuning) {
+	const exportRun = renderTrajectory(tuning);
+	// The pattern must sum to its own length so the preview advances content
+	// time at the same average rate as the export. Otherwise this measures a
+	// systematic clock drift rather than the effect of uneven frame pacing,
+	// which is the thing that actually differs between the two paths.
+	const jitter = [0.5, 2, 1, 0.5, 1];
+	const previewRun = renderTrajectory(
+		tuning,
+		jitter.map((multiplier) => FRAME_MS * multiplier),
+	);
+
+	let maxScale = 0;
+	let maxPanPx = 0;
+	// Divergence that survives once the camera has settled would be a real
+	// error; divergence only while the camera is moving is a timing artefact
+	// that closes itself. They warrant very different responses, so measure
+	// both. "Settled" = the tail of the clip, after the last zoom has ended.
+	let settledScale = 0;
+	let settledPanPx = 0;
+	for (let i = 0; i < exportRun.length; i += 1) {
+		const scaleDelta = Math.abs(exportRun[i].scale - previewRun[i].scale);
+		const panDelta = Math.hypot(
+			exportRun[i].x - previewRun[i].x,
+			exportRun[i].y - previewRun[i].y,
+		);
+		maxScale = Math.max(maxScale, scaleDelta);
+		maxPanPx = Math.max(maxPanPx, panDelta);
+		if (exportRun[i].timeMs > 8500) {
+			settledScale = Math.max(settledScale, scaleDelta);
+			settledPanPx = Math.max(settledPanPx, panDelta);
+		}
+	}
+	return { maxScale, maxPanPx, settledScale, settledPanPx };
+}
+
+function parseArgs(): Tuning {
+	const args = process.argv.slice(2);
+	const read = (flag: string) => {
+		const i = args.indexOf(`--${flag}`);
+		return i >= 0 ? args[i + 1] : undefined;
+	};
+	const num = (flag: string, fallback: number) => {
+		const raw = read(flag);
+		const parsed = raw === undefined ? Number.NaN : Number(raw);
+		return Number.isFinite(parsed) ? parsed : fallback;
+	};
+	const easing = (flag: string, fallback: ZoomTransitionEasing) =>
+		(read(flag) as ZoomTransitionEasing | undefined) ?? fallback;
+
+	return {
+		label: "candidate",
+		zoomSmoothness: num("smoothness", 0.7),
+		cameraSpringStiffnessMultiplier: num("stiffness", CURRENT.cameraSpringStiffnessMultiplier),
+		cameraSpringDampingMultiplier: num("damping", CURRENT.cameraSpringDampingMultiplier),
+		cameraSpringMassMultiplier: num("mass", CURRENT.cameraSpringMassMultiplier),
+		zoomInDurationMs: num("zoom-in-ms", CURRENT.zoomInDurationMs),
+		zoomOutDurationMs: num("zoom-out-ms", CURRENT.zoomOutDurationMs),
+		zoomInEasing: easing("zoom-in-easing", CURRENT.zoomInEasing),
+		zoomOutEasing: easing("zoom-out-easing", CURRENT.zoomOutEasing),
+	};
+}
+
+function polyline(samples: Sample[], pick: (s: Sample) => number, min: number, max: number) {
+	const span = max - min || 1;
+	return samples
+		.map((s) => {
+			const px = (s.timeMs / DURATION_MS) * 960;
+			const py = 220 - ((pick(s) - min) / span) * 200;
+			return `${px.toFixed(1)},${py.toFixed(1)}`;
+		})
+		.join(" ");
+}
+
+function chart(title: string, a: Sample[], b: Sample[], pick: (s: Sample) => number) {
+	const values = [...a, ...b].map(pick);
+	const min = Math.min(...values);
+	const max = Math.max(...values);
+	return `
+    <section>
+      <h2>${title}</h2>
+      <svg viewBox="0 0 960 240" width="100%" height="240" role="img">
+        <rect x="0" y="0" width="960" height="240" fill="#0e0e12" />
+        <polyline points="${polyline(a, pick, min, max)}" fill="none" stroke="#7dd3fc" stroke-width="2" />
+        <polyline points="${polyline(b, pick, min, max)}" fill="none" stroke="#f0a030" stroke-width="2" />
+      </svg>
+      <p class="range">min ${min.toFixed(3)} · max ${max.toFixed(3)}</p>
+    </section>`;
+}
+
+function main() {
+	const candidate = parseArgs();
+	const currentRun = renderTrajectory(CURRENT);
+	const candidateRun = renderTrajectory(candidate);
+	const divergence = measurePreviewExportDivergence(CURRENT);
+
+	const describe = (t: Tuning) =>
+		`smoothness ${t.zoomSmoothness} · spring ${t.cameraSpringStiffnessMultiplier}/${t.cameraSpringDampingMultiplier}/${t.cameraSpringMassMultiplier} · ` +
+		`in ${Math.round(t.zoomInDurationMs)}ms ${t.zoomInEasing} · out ${Math.round(t.zoomOutDurationMs)}ms ${t.zoomOutEasing}`;
+
+	const html = `<!doctype html>
+<meta charset="utf-8">
+<title>Camera tuning comparison</title>
+<style>
+  body { font: 14px/1.5 system-ui, sans-serif; background: #08080b; color: #e6e6ea; margin: 24px auto; max-width: 1000px; }
+  h1 { font-size: 18px; } h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .08em; color: #9b9ba6; }
+  .key { display: flex; gap: 24px; margin-bottom: 20px; }
+  .swatch { display: inline-block; width: 12px; height: 12px; margin-right: 6px; vertical-align: -1px; }
+  .range { color: #6f6f7a; font-size: 12px; margin-top: 4px; }
+  .note { border-left: 2px solid #2a2a33; padding-left: 12px; color: #9b9ba6; }
+</style>
+<h1>Camera tuning comparison</h1>
+<div class="key">
+  <div><span class="swatch" style="background:#7dd3fc"></span><strong>${CURRENT.label}</strong><br>${describe(CURRENT)}</div>
+  <div><span class="swatch" style="background:#f0a030"></span><strong>${candidate.label}</strong><br>${describe(candidate)}</div>
+</div>
+${chart("Camera scale", currentRun, candidateRun, (s) => s.scale)}
+${chart("Pan X (stage px)", currentRun, candidateRun, (s) => s.x)}
+${chart("Pan Y (stage px)", currentRun, candidateRun, (s) => s.y)}
+<p class="note">
+  Both sides use identical source regions and duration; only the tuning differs.
+  Every frame is stepped through the spring at a fixed ${FRAME_RATE}fps content-time
+  delta, matching the export path — the camera spring does not run while
+  scrubbing, so scrubbed frames cannot be used to judge a spring change.
+</p>
+<p class="note">
+  Preview vs export divergence at the current defaults, over this clip with a
+  jittered frame delta whose mean matches the export rate.
+  Peak while moving: scale ${divergence.maxScale.toExponential(2)},
+  pan ${divergence.maxPanPx.toFixed(2)} stage px of 1920.
+  Once settled: scale ${divergence.settledScale.toExponential(2)},
+  pan ${divergence.settledPanPx.toExponential(2)} px.
+</p>
+`;
+
+	// release/ is already gitignored, so the report never shows up as a
+	// stray untracked file after a comparison run.
+	const dir = resolve(process.cwd(), "release");
+	mkdirSync(dir, { recursive: true });
+	const out = resolve(dir, "camera-tuning-comparison.html");
+	writeFileSync(out, html);
+	console.log(`wrote ${out}`);
+	console.log(
+		`preview/export divergence while moving — scale ${divergence.maxScale.toExponential(3)}, pan ${divergence.maxPanPx.toFixed(3)}px of ${STAGE.width}`,
+	);
+	console.log(
+		`preview/export divergence once settled — scale ${divergence.settledScale.toExponential(3)}, pan ${divergence.settledPanPx.toExponential(3)}px`,
+	);
+}
+
+main();

--- a/apps/desktop/src/components/editor/SettingsPanel.tsx
+++ b/apps/desktop/src/components/editor/SettingsPanel.tsx
@@ -70,6 +70,7 @@ import {
   DEFAULT_CURSOR_CLICK_BOUNCE_DURATION,
   DEFAULT_CURSOR_CLICK_EFFECT,
   DEFAULT_CONNECTED_ZOOM_EASING,
+  DEFAULT_ZOOM_DRIFT,
   DEFAULT_CURSOR_MOTION_BLUR,
   DEFAULT_ZOOM_IN_EASING,
   DEFAULT_ZOOM_OUT_EASING,
@@ -188,6 +189,8 @@ interface SettingsPanelProps {
   cameraSpringMassMultiplier?: number;
   onCameraSpringMassMultiplierChange?: (multiplier: number) => void;
   zoomClassicMode?: boolean;
+  zoomDrift?: number;
+  onZoomDriftChange?: (value: number) => void;
   selectedZoomInstant?: boolean;
   onZoomInstantChange?: (instant: boolean) => void;
   onZoomClassicModeChange?: (enabled: boolean) => void;
@@ -510,6 +513,8 @@ function SettingsPanelImpl({
   onCameraSpringMassMultiplierChange,
   zoomClassicMode = false,
   onZoomClassicModeChange,
+  zoomDrift = DEFAULT_ZOOM_DRIFT,
+  onZoomDriftChange,
   selectedZoomInstant = false,
   onZoomInstantChange,
   zoomInEasing = DEFAULT_ZOOM_IN_EASING,
@@ -1026,6 +1031,7 @@ function SettingsPanelImpl({
   };
 
   const resetZoomSection = () => {
+    onZoomDriftChange?.(initialEditorPreferences.zoomDrift);
     onZoomMotionBlurTuningChange?.(
       initialEditorPreferences.zoomMotionBlurTuning,
     );
@@ -1433,6 +1439,8 @@ function SettingsPanelImpl({
           resetZoomSection={resetZoomSection}
           zoomClassicMode={zoomClassicMode}
           onZoomClassicModeChange={onZoomClassicModeChange}
+          zoomDrift={zoomDrift}
+          onZoomDriftChange={onZoomDriftChange}
           selectedZoomInstant={selectedZoomInstant}
           onZoomInstantChange={onZoomInstantChange}
           zoomInEasing={zoomInEasing}

--- a/apps/desktop/src/components/editor/SettingsPanel.tsx
+++ b/apps/desktop/src/components/editor/SettingsPanel.tsx
@@ -188,6 +188,8 @@ interface SettingsPanelProps {
   cameraSpringMassMultiplier?: number;
   onCameraSpringMassMultiplierChange?: (multiplier: number) => void;
   zoomClassicMode?: boolean;
+  selectedZoomInstant?: boolean;
+  onZoomInstantChange?: (instant: boolean) => void;
   onZoomClassicModeChange?: (enabled: boolean) => void;
   cursorMotionBlur?: number;
   onCursorMotionBlurChange?: (amount: number) => void;
@@ -508,6 +510,8 @@ function SettingsPanelImpl({
   onCameraSpringMassMultiplierChange,
   zoomClassicMode = false,
   onZoomClassicModeChange,
+  selectedZoomInstant = false,
+  onZoomInstantChange,
   zoomInEasing = DEFAULT_ZOOM_IN_EASING,
   onZoomInEasingChange,
   zoomOutEasing = DEFAULT_ZOOM_OUT_EASING,
@@ -1429,6 +1433,8 @@ function SettingsPanelImpl({
           resetZoomSection={resetZoomSection}
           zoomClassicMode={zoomClassicMode}
           onZoomClassicModeChange={onZoomClassicModeChange}
+          selectedZoomInstant={selectedZoomInstant}
+          onZoomInstantChange={onZoomInstantChange}
           zoomInEasing={zoomInEasing}
           onZoomInEasingChange={onZoomInEasingChange}
           zoomOutEasing={zoomOutEasing}

--- a/apps/desktop/src/components/editor/SettingsPanel.tsx
+++ b/apps/desktop/src/components/editor/SettingsPanel.tsx
@@ -69,7 +69,10 @@ import {
   DEFAULT_CROP_REGION,
   DEFAULT_CURSOR_CLICK_BOUNCE_DURATION,
   DEFAULT_CURSOR_CLICK_EFFECT,
+  DEFAULT_CONNECTED_ZOOM_EASING,
   DEFAULT_CURSOR_MOTION_BLUR,
+  DEFAULT_ZOOM_IN_EASING,
+  DEFAULT_ZOOM_OUT_EASING,
   DEFAULT_CURSOR_STYLE,
   DEFAULT_CURSOR_SWAY,
   DEFAULT_PADDING,
@@ -505,6 +508,12 @@ function SettingsPanelImpl({
   onCameraSpringMassMultiplierChange,
   zoomClassicMode = false,
   onZoomClassicModeChange,
+  zoomInEasing = DEFAULT_ZOOM_IN_EASING,
+  onZoomInEasingChange,
+  zoomOutEasing = DEFAULT_ZOOM_OUT_EASING,
+  onZoomOutEasingChange,
+  connectedZoomEasing = DEFAULT_CONNECTED_ZOOM_EASING,
+  onConnectedZoomEasingChange,
   cursorMotionBlur = DEFAULT_CURSOR_MOTION_BLUR,
   onCursorMotionBlurChange,
   cursorClickBounce = 1,
@@ -1420,6 +1429,12 @@ function SettingsPanelImpl({
           resetZoomSection={resetZoomSection}
           zoomClassicMode={zoomClassicMode}
           onZoomClassicModeChange={onZoomClassicModeChange}
+          zoomInEasing={zoomInEasing}
+          onZoomInEasingChange={onZoomInEasingChange}
+          zoomOutEasing={zoomOutEasing}
+          onZoomOutEasingChange={onZoomOutEasingChange}
+          connectedZoomEasing={connectedZoomEasing}
+          onConnectedZoomEasingChange={onConnectedZoomEasingChange}
           onZoomDelete={onZoomDelete}
           ZOOM_DEPTH_OPTIONS={ZOOM_DEPTH_OPTIONS}
           renderExtensionPanelsForSections={renderExtensionPanelsForSections}

--- a/apps/desktop/src/components/editor/SettingsPanel.tsx
+++ b/apps/desktop/src/components/editor/SettingsPanel.tsx
@@ -32,7 +32,7 @@ import minimalCursorUrl from "@/assets/cursors/custom/minimal-cursor.svg";
 import { useI18n, useScopedT } from "../../contexts/I18nContext";
 import { AnnotationSettingsPanel } from "./AnnotationSettingsPanel";
 import {
-  CURSOR_MOTION_PRESETS,
+  applyCursorMotionPreset,
   type CursorMotionPresetId,
   getMatchingCursorMotionPresetId,
 } from "./utils/cursor-motion-presets";
@@ -70,6 +70,7 @@ import {
   DEFAULT_CURSOR_CLICK_BOUNCE_DURATION,
   DEFAULT_CURSOR_CLICK_EFFECT,
   DEFAULT_CONNECTED_ZOOM_EASING,
+  DEFAULT_ZOOM_SMOOTHNESS,
   DEFAULT_ZOOM_DRIFT,
   DEFAULT_CURSOR_MOTION_BLUR,
   DEFAULT_ZOOM_IN_EASING,
@@ -189,6 +190,8 @@ interface SettingsPanelProps {
   cameraSpringMassMultiplier?: number;
   onCameraSpringMassMultiplierChange?: (multiplier: number) => void;
   zoomClassicMode?: boolean;
+  zoomSmoothness?: number;
+  onZoomSmoothnessChange?: (value: number) => void;
   zoomDrift?: number;
   onZoomDriftChange?: (value: number) => void;
   selectedZoomInstant?: boolean;
@@ -513,6 +516,8 @@ function SettingsPanelImpl({
   onCameraSpringMassMultiplierChange,
   zoomClassicMode = false,
   onZoomClassicModeChange,
+  zoomSmoothness = DEFAULT_ZOOM_SMOOTHNESS,
+  onZoomSmoothnessChange,
   zoomDrift = DEFAULT_ZOOM_DRIFT,
   onZoomDriftChange,
   selectedZoomInstant = false,
@@ -1070,11 +1075,21 @@ function SettingsPanelImpl({
     onCursorSwayChange?.(initialEditorPreferences.cursorSway);
   };
 
-  const activeMotionPresetId = useMemo(() => {
-    return (
+  // Null when the current values are not a preset. Deliberately not
+  // defaulted: highlighting a preset the project does not have would describe
+  // a camera it is not using.
+  const activeMotionPresetId = useMemo(
+    () =>
       getMatchingCursorMotionPresetId({
+        zoomSmoothness,
+        cameraSpringStiffnessMultiplier,
+        cameraSpringDampingMultiplier,
+        cameraSpringMassMultiplier,
         zoomInDurationMs,
         zoomOutDurationMs,
+        zoomInEasing,
+        zoomOutEasing,
+        connectedZoomEasing,
         cursorSize,
         cursorSmoothing,
         cursorSpringStiffnessMultiplier,
@@ -1083,37 +1098,56 @@ function SettingsPanelImpl({
         cursorMotionBlur,
         cursorClickBounce,
         cursorClickBounceDuration,
-      }) ?? "focused"
-    );
-  }, [
-    cursorClickBounce,
-    cursorClickBounceDuration,
-    cursorMotionBlur,
-    cursorSize,
-    cursorSmoothing,
-    cursorSpringDampingMultiplier,
-    cursorSpringMassMultiplier,
-    cursorSpringStiffnessMultiplier,
-    zoomInDurationMs,
-    zoomOutDurationMs,
-  ]);
+      }),
+    [
+      zoomSmoothness,
+      cameraSpringStiffnessMultiplier,
+      cameraSpringDampingMultiplier,
+      cameraSpringMassMultiplier,
+      zoomInDurationMs,
+      zoomOutDurationMs,
+      zoomInEasing,
+      zoomOutEasing,
+      connectedZoomEasing,
+      cursorSize,
+      cursorSmoothing,
+      cursorSpringStiffnessMultiplier,
+      cursorSpringDampingMultiplier,
+      cursorSpringMassMultiplier,
+      cursorMotionBlur,
+      cursorClickBounce,
+      cursorClickBounceDuration,
+    ],
+  );
 
+  // One handler per preset field. The map is required, so a field added to
+  // CursorMotionPresetValues will not compile until it is wired to a control.
   const applyMotionPreset = (presetId: CursorMotionPresetId) => {
-    const preset = CURSOR_MOTION_PRESETS[presetId];
-    onZoomInDurationMsChange?.(preset.zoomInDurationMs);
-    onZoomOutDurationMsChange?.(preset.zoomOutDurationMs);
-    onCursorSizeChange?.(preset.cursorSize);
-    onCursorSmoothingChange?.(preset.cursorSmoothing);
-    onCursorSpringStiffnessMultiplierChange?.(
-      preset.cursorSpringStiffnessMultiplier,
-    );
-    onCursorSpringDampingMultiplierChange?.(
-      preset.cursorSpringDampingMultiplier,
-    );
-    onCursorSpringMassMultiplierChange?.(preset.cursorSpringMassMultiplier);
-    onCursorMotionBlurChange?.(preset.cursorMotionBlur);
-    onCursorClickBounceChange?.(preset.cursorClickBounce);
-    onCursorClickBounceDurationChange?.(preset.cursorClickBounceDuration);
+    applyCursorMotionPreset(presetId, {
+      zoomSmoothness: (v) => onZoomSmoothnessChange?.(v),
+      cameraSpringStiffnessMultiplier: (v) =>
+        onCameraSpringStiffnessMultiplierChange?.(v),
+      cameraSpringDampingMultiplier: (v) =>
+        onCameraSpringDampingMultiplierChange?.(v),
+      cameraSpringMassMultiplier: (v) =>
+        onCameraSpringMassMultiplierChange?.(v),
+      zoomInDurationMs: (v) => onZoomInDurationMsChange?.(v),
+      zoomOutDurationMs: (v) => onZoomOutDurationMsChange?.(v),
+      zoomInEasing: (v) => onZoomInEasingChange?.(v),
+      zoomOutEasing: (v) => onZoomOutEasingChange?.(v),
+      connectedZoomEasing: (v) => onConnectedZoomEasingChange?.(v),
+      cursorSize: (v) => onCursorSizeChange?.(v),
+      cursorSmoothing: (v) => onCursorSmoothingChange?.(v),
+      cursorSpringStiffnessMultiplier: (v) =>
+        onCursorSpringStiffnessMultiplierChange?.(v),
+      cursorSpringDampingMultiplier: (v) =>
+        onCursorSpringDampingMultiplierChange?.(v),
+      cursorSpringMassMultiplier: (v) =>
+        onCursorSpringMassMultiplierChange?.(v),
+      cursorMotionBlur: (v) => onCursorMotionBlurChange?.(v),
+      cursorClickBounce: (v) => onCursorClickBounceChange?.(v),
+      cursorClickBounceDuration: (v) => onCursorClickBounceDurationChange?.(v),
+    });
   };
 
   const resetFrameSection = () => {
@@ -1353,6 +1387,8 @@ function SettingsPanelImpl({
         onCameraSpringStiffnessMultiplierChange={
           onCameraSpringStiffnessMultiplierChange
         }
+        zoomSmoothness={zoomSmoothness}
+        onZoomSmoothnessChange={onZoomSmoothnessChange}
         initialCameraSpringStiffnessMultiplier={
           initialEditorPreferences.cameraSpringStiffnessMultiplier
         }

--- a/apps/desktop/src/components/editor/playback.tsx
+++ b/apps/desktop/src/components/editor/playback.tsx
@@ -561,16 +561,23 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
           connectZooms,
           zoomInDurationMs,
           zoomOutDurationMs,
+          zoomInEasing,
+          zoomOutEasing,
+          connectedZoomEasing,
         }),
-      [connectZooms, zoomInDurationMs, zoomOutDurationMs],
+      [
+        connectZooms,
+        zoomInDurationMs,
+        zoomOutDurationMs,
+        zoomInEasing,
+        zoomOutEasing,
+        connectedZoomEasing,
+      ],
     );
     const cameraMotionOptionsRef = useRef(cameraMotionOptions);
     const zoomInOverlapMsRef = useRef(zoomInOverlapMs);
     const connectedZoomGapMsRef = useRef(connectedZoomGapMs);
     const connectedZoomDurationMsRef = useRef(connectedZoomDurationMs);
-    const zoomInEasingRef = useRef(zoomInEasing);
-    const zoomOutEasingRef = useRef(zoomOutEasing);
-    const connectedZoomEasingRef = useRef(connectedZoomEasing);
     const videoReadyRafRef = useRef<number | null>(null);
     const cursorOverlayRef = useRef<PixiCursorOverlay | null>(null);
     const cursorEffectsCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -1622,18 +1629,6 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
     useEffect(() => {
       connectedZoomDurationMsRef.current = connectedZoomDurationMs;
     }, [connectedZoomDurationMs]);
-
-    useEffect(() => {
-      zoomInEasingRef.current = zoomInEasing;
-    }, [zoomInEasing]);
-
-    useEffect(() => {
-      zoomOutEasingRef.current = zoomOutEasing;
-    }, [zoomOutEasing]);
-
-    useEffect(() => {
-      connectedZoomEasingRef.current = connectedZoomEasing;
-    }, [connectedZoomEasing]);
 
     useEffect(() => {
       cursorTelemetryRef.current = cursorTelemetry;

--- a/apps/desktop/src/components/editor/playback.tsx
+++ b/apps/desktop/src/components/editor/playback.tsx
@@ -149,6 +149,7 @@ import { getWebcamMediaTargetTimeSeconds } from "./videoPlayback/webcamSync";
 import {
   buildCameraMotionOptions,
   findDominantRegion,
+  isInstantZoomCut,
 } from "./videoPlayback/zoomRegionUtils";
 import {
   applyZoomTransform,
@@ -172,6 +173,8 @@ type PlaybackAnimationState = {
   progress: number;
   x: number;
   y: number;
+  /** True only on the frame an instant zoom lands. See isInstantZoomCut. */
+  instantCut: boolean;
 };
 
 function createPlaybackAnimationState(): PlaybackAnimationState {
@@ -183,6 +186,7 @@ function createPlaybackAnimationState(): PlaybackAnimationState {
     progress: 0,
     x: 0,
     y: 0,
+    instantCut: false,
   };
 }
 
@@ -2243,6 +2247,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
           focusY: focus.cy,
           isPlaying: isPlayingRef.current,
           motionBlurAmount: zoomMotionBlurRef.current,
+          suppressMotionBlur: state.instantCut,
           motionBlurTuning: zoomMotionBlurTuningRef.current,
           transformOverride: transform,
           motionBlurState: motionBlurStateRef.current,
@@ -2352,10 +2357,12 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 
         const state = animationStateRef.current;
 
+        const instantCut = isInstantZoomCut(region, strength, state.progress);
         state.scale = targetScaleFactor;
         state.focusX = targetFocus.cx;
         state.focusY = targetFocus.cy;
         state.progress = targetProgress;
+        state.instantCut = instantCut;
 
         // Push zoom state to extension host only when values change
         const prevZoom = prevZoomStateRef.current;
@@ -2408,7 +2415,12 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
         const useSpring =
           isPlayingRef.current &&
           !isSeekingRef.current &&
-          !zoomClassicModeRef.current;
+          !zoomClassicModeRef.current &&
+          // An instant zoom has to skip the spring on its landing frame, or
+          // the spring glides the cut over several hundred ms and "instant"
+          // is not instant. Only this frame — the rest of the hold springs
+          // normally so cursor-follow motion stays smooth.
+          !state.instantCut;
 
         let appliedScale: number;
         let appliedX: number;

--- a/apps/desktop/src/components/editor/playback.tsx
+++ b/apps/desktop/src/components/editor/playback.tsx
@@ -567,7 +567,10 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
         buildCameraMotionOptions({
           connectZooms,
           zoomInDurationMs,
+          zoomInOverlapMs,
           zoomOutDurationMs,
+          connectedZoomGapMs,
+          connectedZoomDurationMs,
           zoomInEasing,
           zoomOutEasing,
           connectedZoomEasing,
@@ -576,7 +579,10 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
       [
         connectZooms,
         zoomInDurationMs,
+        zoomInOverlapMs,
         zoomOutDurationMs,
+        connectedZoomGapMs,
+        connectedZoomDurationMs,
         zoomInEasing,
         zoomOutEasing,
         connectedZoomEasing,
@@ -584,9 +590,6 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
       ],
     );
     const cameraMotionOptionsRef = useRef(cameraMotionOptions);
-    const zoomInOverlapMsRef = useRef(zoomInOverlapMs);
-    const connectedZoomGapMsRef = useRef(connectedZoomGapMs);
-    const connectedZoomDurationMsRef = useRef(connectedZoomDurationMs);
     const videoReadyRafRef = useRef<number | null>(null);
     const cursorOverlayRef = useRef<PixiCursorOverlay | null>(null);
     const cursorEffectsCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -1626,18 +1629,6 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
     useEffect(() => {
       cameraMotionOptionsRef.current = cameraMotionOptions;
     }, [cameraMotionOptions]);
-
-    useEffect(() => {
-      zoomInOverlapMsRef.current = zoomInOverlapMs;
-    }, [zoomInOverlapMs]);
-
-    useEffect(() => {
-      connectedZoomGapMsRef.current = connectedZoomGapMs;
-    }, [connectedZoomGapMs]);
-
-    useEffect(() => {
-      connectedZoomDurationMsRef.current = connectedZoomDurationMs;
-    }, [connectedZoomDurationMs]);
 
     useEffect(() => {
       cursorTelemetryRef.current = cursorTelemetry;

--- a/apps/desktop/src/components/editor/playback.tsx
+++ b/apps/desktop/src/components/editor/playback.tsx
@@ -128,6 +128,7 @@ import {
   DEFAULT_ZOOM_IN_DURATION_MS,
   DEFAULT_ZOOM_IN_EASING,
   DEFAULT_ZOOM_IN_OVERLAP_MS,
+  DEFAULT_ZOOM_DRIFT,
   DEFAULT_ZOOM_MOTION_BLUR,
   DEFAULT_ZOOM_MOTION_BLUR_TUNING,
   DEFAULT_ZOOM_OUT_DURATION_MS,
@@ -386,6 +387,7 @@ interface VideoPlaybackProps {
   zoomSmoothness?: number;
   zoomClassicMode?: boolean;
   zoomMotionBlur?: number;
+  zoomDrift?: number;
   zoomMotionBlurTuning?: ZoomMotionBlurTuning;
   cursorMotionBlur?: number;
   cursorClickBounce?: number;
@@ -465,6 +467,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
       zoomSmoothness = 0.5,
       zoomClassicMode = false,
       zoomMotionBlur = DEFAULT_ZOOM_MOTION_BLUR,
+      zoomDrift = DEFAULT_ZOOM_DRIFT,
       zoomMotionBlurTuning = DEFAULT_ZOOM_MOTION_BLUR_TUNING,
       cursorMotionBlur = DEFAULT_CURSOR_MOTION_BLUR,
       cursorClickBounce = DEFAULT_CURSOR_CLICK_BOUNCE,
@@ -568,6 +571,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
           zoomInEasing,
           zoomOutEasing,
           connectedZoomEasing,
+          zoomDrift,
         }),
       [
         connectZooms,
@@ -576,6 +580,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
         zoomInEasing,
         zoomOutEasing,
         connectedZoomEasing,
+        zoomDrift,
       ],
     );
     const cameraMotionOptionsRef = useRef(cameraMotionOptions);

--- a/apps/desktop/src/components/editor/playback.tsx
+++ b/apps/desktop/src/components/editor/playback.tsx
@@ -146,7 +146,10 @@ import { layoutVideoContent as layoutVideoContentUtil } from "./videoPlayback/la
 import { updateOverlayIndicator } from "./videoPlayback/overlayUtils";
 import { createVideoEventHandlers } from "./videoPlayback/videoEventHandlers";
 import { getWebcamMediaTargetTimeSeconds } from "./videoPlayback/webcamSync";
-import { findDominantRegion } from "./videoPlayback/zoomRegionUtils";
+import {
+  buildCameraMotionOptions,
+  findDominantRegion,
+} from "./videoPlayback/zoomRegionUtils";
 import {
   applyZoomTransform,
   computeFocusFromTransform,
@@ -550,10 +553,19 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
     const lastWebcamSyncTimeRef = useRef<number | null>(null);
     const lastBackgroundSyncTimeRef = useRef<number | null>(null);
     const bgVideoRef = useRef<HTMLVideoElement | null>(null);
-    const connectZoomsRef = useRef(connectZooms);
-    const zoomInDurationMsRef = useRef(zoomInDurationMs);
+    // VideoPlayback re-renders every frame during playback (it subscribes to
+    // the live time store), so this is memoised rather than rebuilt per render.
+    const cameraMotionOptions = useMemo(
+      () =>
+        buildCameraMotionOptions({
+          connectZooms,
+          zoomInDurationMs,
+          zoomOutDurationMs,
+        }),
+      [connectZooms, zoomInDurationMs, zoomOutDurationMs],
+    );
+    const cameraMotionOptionsRef = useRef(cameraMotionOptions);
     const zoomInOverlapMsRef = useRef(zoomInOverlapMs);
-    const zoomOutDurationMsRef = useRef(zoomOutDurationMs);
     const connectedZoomGapMsRef = useRef(connectedZoomGapMs);
     const connectedZoomDurationMsRef = useRef(connectedZoomDurationMs);
     const zoomInEasingRef = useRef(zoomInEasing);
@@ -1596,20 +1608,12 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
     }, [pixiReady]);
 
     useEffect(() => {
-      connectZoomsRef.current = connectZooms;
-    }, [connectZooms]);
-
-    useEffect(() => {
-      zoomInDurationMsRef.current = zoomInDurationMs;
-    }, [zoomInDurationMs]);
+      cameraMotionOptionsRef.current = cameraMotionOptions;
+    }, [cameraMotionOptions]);
 
     useEffect(() => {
       zoomInOverlapMsRef.current = zoomInOverlapMs;
     }, [zoomInOverlapMs]);
-
-    useEffect(() => {
-      zoomOutDurationMsRef.current = zoomOutDurationMs;
-    }, [zoomOutDurationMs]);
 
     useEffect(() => {
       connectedZoomGapMsRef.current = connectedZoomGapMs;
@@ -2266,11 +2270,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
         playbackSessionDebug.recordRenderTick(tickStart);
 
         const { region, strength, blendedScale, transition } =
-          findDominantRegion(zoomRegionsRef.current, currentTimeRef.current, {
-            connectZooms: connectZoomsRef.current,
-            zoomInDurationMs: zoomInDurationMsRef.current,
-            zoomOutDurationMs: zoomOutDurationMsRef.current,
-          });
+          findDominantRegion(
+            zoomRegionsRef.current,
+            currentTimeRef.current,
+            cameraMotionOptionsRef.current,
+          );
 
         const defaultFocus = DEFAULT_FOCUS;
         let targetScaleFactor = 1;

--- a/apps/desktop/src/components/editor/settings-panel/MotionPresetCards.tsx
+++ b/apps/desktop/src/components/editor/settings-panel/MotionPresetCards.tsx
@@ -17,14 +17,12 @@ export function MotionPresetCards({
   onApply: (presetId: CursorMotionPresetId) => void;
   tSettings: (key: string, fallback?: string) => string;
 }) {
-  const activePreset = activePresetId ?? MOTION_PRESET_ORDER[0];
-
   return (
     <div className="space-y-2">
       <div className="flex rounded-lg border border-border bg-foreground/[0.04] p-0.5">
         {MOTION_PRESET_ORDER.map((presetId) => {
           const Icon = presetId === "focused" ? IconClick : IconPresentation;
-          const isActive = activePreset === presetId;
+          const isActive = activePresetId === presetId;
 
           return (
             <button
@@ -39,13 +37,20 @@ export function MotionPresetCards({
               )}
             >
               <Icon className="h-3.5 w-3.5" />
-              <span>{tSettings(`effects.motionPresets.${presetId}.label`)}</span>
+              <span>
+                {tSettings(`effects.motionPresets.${presetId}.label`)}
+              </span>
             </button>
           );
         })}
       </div>
       <p className="text-[10px] leading-4 text-muted-foreground/70">
-        {tSettings(`effects.motionPresets.${activePreset}.description`)}
+        {activePresetId
+          ? tSettings(`effects.motionPresets.${activePresetId}.description`)
+          : tSettings(
+              "effects.motionPresets.custom",
+              "Custom motion. Pick a preset to start from a known feel.",
+            )}
       </p>
     </div>
   );

--- a/apps/desktop/src/components/editor/settings-panel/SettingsSection.tsx
+++ b/apps/desktop/src/components/editor/settings-panel/SettingsSection.tsx
@@ -13,6 +13,7 @@ import { SectionLabel } from "./SectionLabel";
 import { MotionPresetCards } from "./MotionPresetCards";
 import { KeyboardShortcutsDialog } from "../help";
 import Scrubber from "@/components/ui/scrubber";
+import { DEFAULT_ZOOM_SMOOTHNESS } from "@/types/editor";
 import { InfoTooltip } from "./shared";
 import type { AppLocale } from "@/i18n/config";
 import { SUPPORTED_LOCALES } from "@/i18n/config";
@@ -31,7 +32,7 @@ interface SettingsSectionProps {
   onAutoApplyFreshRecordingAutoZoomsChange?: (value: boolean) => void;
   connectZooms: boolean;
   onConnectZoomsChange?: (value: boolean) => void;
-  activeMotionPresetId: CursorMotionPresetId;
+  activeMotionPresetId: CursorMotionPresetId | null;
   onApplyMotionPreset: (presetId: CursorMotionPresetId) => void;
   showDevMotionControls: boolean;
   nativeCaptureUnavailableSession: boolean;
@@ -39,6 +40,8 @@ interface SettingsSectionProps {
   zoomMotionBlurTuning: ZoomMotionBlurTuning;
   initialZoomMotionBlurTuning: ZoomMotionBlurTuning;
   onZoomMotionBlurTuningChange?: (tuning: ZoomMotionBlurTuning) => void;
+  zoomSmoothness: number;
+  onZoomSmoothnessChange?: (value: number) => void;
   cameraSpringStiffnessMultiplier: number;
   onCameraSpringStiffnessMultiplierChange?: (value: number) => void;
   initialCameraSpringStiffnessMultiplier: number;
@@ -131,6 +134,8 @@ export function SettingsSection({
   zoomMotionBlurTuning,
   initialZoomMotionBlurTuning,
   onZoomMotionBlurTuningChange,
+  zoomSmoothness,
+  onZoomSmoothnessChange,
   cameraSpringStiffnessMultiplier,
   onCameraSpringStiffnessMultiplierChange,
   initialCameraSpringStiffnessMultiplier,
@@ -249,6 +254,72 @@ export function SettingsSection({
             className="data-[state=checked]:bg-primary scale-75"
           />
         </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={tSettings("effects.cameraSpringControls", "Camera Spring")}
+        description={tSettings(
+          "effects.cameraSpringControlsHint",
+          "Tune camera movement physics. Motion presets set these; every one stays editable here.",
+        )}
+      >
+        <Scrubber
+          label={tSettings("effects.zoomSmoothness", "Camera smoothness")}
+          value={zoomSmoothness}
+          defaultValue={DEFAULT_ZOOM_SMOOTHNESS}
+          min={0}
+          max={1}
+          step={0.01}
+          decimals={2}
+          onValueChange={(value) => onZoomSmoothnessChange?.(value)}
+        />
+        <ScrubberStack>
+          <Scrubber
+            label={tSettings(
+              "effects.cameraSpringStiffnessMultiplier",
+              "Camera stiffness",
+            )}
+            value={cameraSpringStiffnessMultiplier}
+            defaultValue={initialCameraSpringStiffnessMultiplier}
+            min={0.25}
+            max={3}
+            step={0.01}
+            onValueChange={(value) =>
+              onCameraSpringStiffnessMultiplierChange?.(value)
+            }
+            suffix="×"
+          />
+          <Scrubber
+            label={tSettings(
+              "effects.cameraSpringDampingMultiplier",
+              "Camera damping",
+            )}
+            value={cameraSpringDampingMultiplier}
+            defaultValue={initialCameraSpringDampingMultiplier}
+            min={0.25}
+            max={3}
+            step={0.01}
+            onValueChange={(value) =>
+              onCameraSpringDampingMultiplierChange?.(value)
+            }
+            suffix="×"
+          />
+          <Scrubber
+            label={tSettings(
+              "effects.cameraSpringMassMultiplier",
+              "Camera mass",
+            )}
+            value={cameraSpringMassMultiplier}
+            defaultValue={initialCameraSpringMassMultiplier}
+            min={0.25}
+            max={3}
+            step={0.01}
+            onValueChange={(value) =>
+              onCameraSpringMassMultiplierChange?.(value)
+            }
+            suffix="×"
+          />
+        </ScrubberStack>
       </SettingsGroup>
 
       <SettingsGroup
@@ -401,65 +472,6 @@ export function SettingsSection({
                 })
               }
               decimals={3}
-            />
-          </ScrubberStack>
-
-          <ScrubberStack>
-            <div className="flex items-center gap-1.5">
-              <SectionLabel>
-                {tSettings("effects.cameraSpringControls", "Camera Spring")}
-              </SectionLabel>
-              <InfoTooltip>
-                {tSettings(
-                  "effects.cameraSpringControlsHint",
-                  "Tune camera movement physics.",
-                )}
-              </InfoTooltip>
-            </div>
-            <Scrubber
-              label={tSettings(
-                "effects.cameraSpringStiffnessMultiplier",
-                "Camera stiffness",
-              )}
-              value={cameraSpringStiffnessMultiplier}
-              defaultValue={initialCameraSpringStiffnessMultiplier}
-              min={0.25}
-              max={3}
-              step={0.01}
-              onValueChange={(value) =>
-                onCameraSpringStiffnessMultiplierChange?.(value)
-              }
-              suffix="×"
-            />
-            <Scrubber
-              label={tSettings(
-                "effects.cameraSpringDampingMultiplier",
-                "Camera damping",
-              )}
-              value={cameraSpringDampingMultiplier}
-              defaultValue={initialCameraSpringDampingMultiplier}
-              min={0.25}
-              max={3}
-              step={0.01}
-              onValueChange={(value) =>
-                onCameraSpringDampingMultiplierChange?.(value)
-              }
-              suffix="×"
-            />
-            <Scrubber
-              label={tSettings(
-                "effects.cameraSpringMassMultiplier",
-                "Camera mass",
-              )}
-              value={cameraSpringMassMultiplier}
-              defaultValue={initialCameraSpringMassMultiplier}
-              min={0.25}
-              max={3}
-              step={0.01}
-              onValueChange={(value) =>
-                onCameraSpringMassMultiplierChange?.(value)
-              }
-              suffix="×"
             />
           </ScrubberStack>
 

--- a/apps/desktop/src/components/editor/settings-panel/sections/ZoomSection.tsx
+++ b/apps/desktop/src/components/editor/settings-panel/sections/ZoomSection.tsx
@@ -73,6 +73,8 @@ interface ZoomSectionProps {
   onZoomPresetChange?: (presetId: ZoomPresetId) => void;
   resetZoomSection: () => void;
   zoomClassicMode: boolean;
+  selectedZoomInstant: boolean;
+  onZoomInstantChange?: (instant: boolean) => void;
   onZoomClassicModeChange?: (v: boolean) => void;
   zoomInEasing: ZoomTransitionEasing;
   onZoomInEasingChange?: (easing: ZoomTransitionEasing) => void;
@@ -101,6 +103,8 @@ export function ZoomSection({
   resetZoomSection,
   zoomClassicMode,
   onZoomClassicModeChange,
+  selectedZoomInstant,
+  onZoomInstantChange,
   zoomInEasing,
   onZoomInEasingChange,
   zoomOutEasing,
@@ -191,6 +195,25 @@ export function ZoomSection({
                   )}
             </p>
           </div>
+          <div className="rounded-lg bg-foreground/[0.03] px-2.5 py-1.5">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[10px] text-muted-foreground">
+                {tSettings("zoom.instant", "Instant")}
+              </span>
+              <Switch
+                checked={selectedZoomInstant}
+                onCheckedChange={(v) => onZoomInstantChange?.(v)}
+                className="scale-75 data-[state=checked]:bg-primary"
+              />
+            </div>
+            <p className="mt-1 text-[10px] leading-4 text-muted-foreground/70">
+              {tSettings(
+                "zoom.instantDescription",
+                "Cut straight to this zoom instead of easing in. The zoom out is unaffected.",
+              )}
+            </p>
+          </div>
+
           <div className="grid grid-cols-6 gap-1.5">
             {ZOOM_DEPTH_OPTIONS.map((option) => {
               const isActive = selectedZoomDepth === option.depth;
@@ -228,15 +251,23 @@ export function ZoomSection({
         </button>
       </div>
 
-      <div className="flex items-center justify-between rounded-lg bg-foreground/[0.03] px-2.5 py-1.5">
-        <span className="text-[10px] text-muted-foreground">
-          {tSettings("effects.classicZoom", "Classic Animation")}
-        </span>
-        <Switch
-          checked={zoomClassicMode}
-          onCheckedChange={(v) => onZoomClassicModeChange?.(v)}
-          className="data-[state=checked]:bg-primary scale-75"
-        />
+      <div className="rounded-lg bg-foreground/[0.03] px-2.5 py-1.5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[10px] text-muted-foreground">
+            {tSettings("effects.classicZoom", "Classic Animation")}
+          </span>
+          <Switch
+            checked={zoomClassicMode}
+            onCheckedChange={(v) => onZoomClassicModeChange?.(v)}
+            className="data-[state=checked]:bg-primary scale-75"
+          />
+        </div>
+        <p className="mt-1 text-[10px] leading-4 text-muted-foreground/70">
+          {tSettings(
+            "effects.classicZoomDescription",
+            "Drop the camera spring for every zoom. Zooms still ease in — for a hard cut, turn on Instant for that zoom.",
+          )}
+        </p>
       </div>
 
       {!zoomClassicMode && (

--- a/apps/desktop/src/components/editor/settings-panel/sections/ZoomSection.tsx
+++ b/apps/desktop/src/components/editor/settings-panel/sections/ZoomSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import Scrubber from "@/components/ui/scrubber";
 import {
   Select,
   SelectContent,
@@ -73,6 +74,8 @@ interface ZoomSectionProps {
   onZoomPresetChange?: (presetId: ZoomPresetId) => void;
   resetZoomSection: () => void;
   zoomClassicMode: boolean;
+  zoomDrift: number;
+  onZoomDriftChange?: (value: number) => void;
   selectedZoomInstant: boolean;
   onZoomInstantChange?: (instant: boolean) => void;
   onZoomClassicModeChange?: (v: boolean) => void;
@@ -103,6 +106,8 @@ export function ZoomSection({
   resetZoomSection,
   zoomClassicMode,
   onZoomClassicModeChange,
+  zoomDrift,
+  onZoomDriftChange,
   selectedZoomInstant,
   onZoomInstantChange,
   zoomInEasing,
@@ -280,6 +285,22 @@ export function ZoomSection({
       )}
 
       <div className="space-y-1.5">
+        <Scrubber
+          label={tSettings("effects.zoomDrift", "Drift")}
+          value={zoomDrift}
+          defaultValue={0}
+          min={0}
+          max={1}
+          step={0.05}
+          decimals={2}
+          onValueChange={(value) => onZoomDriftChange?.(value)}
+        />
+        <p className="text-[10px] leading-4 text-muted-foreground/70">
+          {tSettings(
+            "effects.zoomDriftHint",
+            "Slow parallax while a zoom is held, so a long hold reads as a camera rather than a crop. Manual zooms only.",
+          )}
+        </p>
         <EasingSelect
           label={tSettings("effects.zoomInEasing", "Zoom In Curve")}
           value={zoomInEasing}

--- a/apps/desktop/src/components/editor/settings-panel/sections/ZoomSection.tsx
+++ b/apps/desktop/src/components/editor/settings-panel/sections/ZoomSection.tsx
@@ -1,13 +1,65 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Delete02Icon as Trash2 } from "@/components/icons";
 import { cn } from "@/lib/utils";
-import type { ZoomDepth, ZoomMode, ZoomPresetId } from "@/types/editor";
+import type {
+  ZoomDepth,
+  ZoomMode,
+  ZoomPresetId,
+  ZoomTransitionEasing,
+} from "@/types/editor";
 import {
   TEMPORAL_MOTION_BLUR_DEFAULT_SAMPLE_COUNT,
   TEMPORAL_MOTION_BLUR_DEFAULT_SHUTTER_FRACTION,
 } from "@/lib/exporter/temporal-motion-blur";
+import { ZOOM_TRANSITION_EASINGS } from "../../videoPlayback/mathUtils";
+
+// Derived from the curve map so a new curve cannot appear in the renderer
+// without appearing in the picker.
+const EASING_OPTIONS = Object.keys(
+  ZOOM_TRANSITION_EASINGS,
+) as ZoomTransitionEasing[];
+
+function EasingSelect({
+  label,
+  value,
+  onChange,
+  tSettings,
+}: {
+  label: string;
+  value: ZoomTransitionEasing;
+  onChange?: (easing: ZoomTransitionEasing) => void;
+  tSettings: (key: string, fallback?: string) => string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-1.5">
+      <span className="text-[10px] text-muted-foreground">{label}</span>
+      <Select
+        value={value}
+        onValueChange={(next) => onChange?.(next as ZoomTransitionEasing)}
+      >
+        <SelectTrigger className="h-6 w-24 border-foreground/10 bg-foreground/[0.03] text-[10px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {EASING_OPTIONS.map((easing) => (
+            <SelectItem key={easing} value={easing} className="text-[10px]">
+              {tSettings(`effects.zoomEasingOptions.${easing}`, easing)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
 
 interface ZoomSectionProps {
   tSettings: (key: string, fallback?: string) => string;
@@ -22,6 +74,12 @@ interface ZoomSectionProps {
   resetZoomSection: () => void;
   zoomClassicMode: boolean;
   onZoomClassicModeChange?: (v: boolean) => void;
+  zoomInEasing: ZoomTransitionEasing;
+  onZoomInEasingChange?: (easing: ZoomTransitionEasing) => void;
+  zoomOutEasing: ZoomTransitionEasing;
+  onZoomOutEasingChange?: (easing: ZoomTransitionEasing) => void;
+  connectedZoomEasing: ZoomTransitionEasing;
+  onConnectedZoomEasingChange?: (easing: ZoomTransitionEasing) => void;
   onZoomDelete?: (id: string) => void;
   ZOOM_DEPTH_OPTIONS: Array<{ depth: ZoomDepth; label: string }>;
   renderExtensionPanelsForSections: (
@@ -43,6 +101,12 @@ export function ZoomSection({
   resetZoomSection,
   zoomClassicMode,
   onZoomClassicModeChange,
+  zoomInEasing,
+  onZoomInEasingChange,
+  zoomOutEasing,
+  onZoomOutEasingChange,
+  connectedZoomEasing,
+  onConnectedZoomEasingChange,
   onZoomDelete,
   ZOOM_DEPTH_OPTIONS,
   renderExtensionPanelsForSections,
@@ -183,6 +247,30 @@ export function ZoomSection({
           )}
         </div>
       )}
+
+      <div className="space-y-1.5">
+        <EasingSelect
+          label={tSettings("effects.zoomInEasing", "Zoom In Curve")}
+          value={zoomInEasing}
+          onChange={onZoomInEasingChange}
+          tSettings={tSettings}
+        />
+        <EasingSelect
+          label={tSettings("effects.zoomOutEasing", "Zoom Out Curve")}
+          value={zoomOutEasing}
+          onChange={onZoomOutEasingChange}
+          tSettings={tSettings}
+        />
+        <EasingSelect
+          label={tSettings(
+            "effects.connectedZoomEasing",
+            "Connected Pan Curve",
+          )}
+          value={connectedZoomEasing}
+          onChange={onConnectedZoomEasingChange}
+          tSettings={tSettings}
+        />
+      </div>
 
       <div className="rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2">
         <div className="text-[10px] text-muted-foreground">

--- a/apps/desktop/src/components/editor/utils/cursor-motion-presets.test.ts
+++ b/apps/desktop/src/components/editor/utils/cursor-motion-presets.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyCursorMotionPreset,
+  CURSOR_MOTION_PRESET_IDS,
+  CURSOR_MOTION_PRESET_KEYS,
+  CURSOR_MOTION_PRESETS,
+  type CursorMotionPresetHandlers,
+  type CursorMotionPresetValues,
+  getMatchingCursorMotionPresetId,
+  resolveCursorMotionPresetId,
+} from "./cursor-motion-presets";
+
+function makeHandlers() {
+  const calls: Partial<Record<keyof CursorMotionPresetValues, unknown>> = {};
+  const handlers = Object.fromEntries(
+    CURSOR_MOTION_PRESET_KEYS.map((key) => [
+      key,
+      vi.fn((value: unknown) => {
+        calls[key] = value;
+      }),
+    ]),
+  ) as unknown as CursorMotionPresetHandlers;
+  return { handlers, calls };
+}
+
+describe("CURSOR_MOTION_PRESETS", () => {
+  it("ships exactly two presets", () => {
+    // Curated multi-value looks are Phase 2 and must not be pre-empted here.
+    expect(CURSOR_MOTION_PRESET_IDS).toEqual(["focused", "smooth"]);
+  });
+
+  it("covers the camera, not just the cursor", () => {
+    for (const key of [
+      "zoomSmoothness",
+      "cameraSpringStiffnessMultiplier",
+      "cameraSpringDampingMultiplier",
+      "cameraSpringMassMultiplier",
+      "zoomInEasing",
+      "zoomOutEasing",
+      "connectedZoomEasing",
+    ] as const) {
+      expect(CURSOR_MOTION_PRESET_KEYS).toContain(key);
+    }
+  });
+
+  it("gives the two presets genuinely different camera feels", () => {
+    // Before this, both presets shipped an identical camera and differed only
+    // in cursor behaviour, so the picker changed nothing about the camera.
+    const focused = CURSOR_MOTION_PRESETS.focused.values;
+    const smooth = CURSOR_MOTION_PRESETS.smooth.values;
+
+    for (const key of [
+      "zoomSmoothness",
+      "cameraSpringStiffnessMultiplier",
+      "cameraSpringDampingMultiplier",
+      "cameraSpringMassMultiplier",
+    ] as const) {
+      expect(focused[key]).not.toBe(smooth[key]);
+    }
+  });
+});
+
+describe("applyCursorMotionPreset", () => {
+  it.each(CURSOR_MOTION_PRESET_IDS)(
+    "writes every declared field for %s",
+    (presetId) => {
+      const { handlers, calls } = makeHandlers();
+      applyCursorMotionPreset(presetId, handlers);
+
+      // Not a subset check: every key the preset declares must be written, or
+      // a preset silently leaves part of the previous look in place.
+      expect(Object.keys(calls).sort()).toEqual(
+        [...CURSOR_MOTION_PRESET_KEYS].sort(),
+      );
+      expect(calls).toEqual(CURSOR_MOTION_PRESETS[presetId].values);
+    },
+  );
+
+  it("writes the zoom smoothness that the old apply path silently dropped", () => {
+    const { handlers } = makeHandlers();
+    applyCursorMotionPreset("smooth", handlers);
+    expect(handlers.zoomSmoothness).toHaveBeenCalledWith(
+      CURSOR_MOTION_PRESETS.smooth.values.zoomSmoothness,
+    );
+  });
+});
+
+describe("getMatchingCursorMotionPresetId", () => {
+  it.each(CURSOR_MOTION_PRESET_IDS)("recognises %s exactly", (presetId) => {
+    expect(
+      getMatchingCursorMotionPresetId(CURSOR_MOTION_PRESETS[presetId].values),
+    ).toBe(presetId);
+  });
+
+  // This is the guard that matters: if a field is added to the preset shape
+  // but the matcher does not compare it, the panel keeps showing a preset as
+  // active after the user has edited that field away from it.
+  it.each(CURSOR_MOTION_PRESET_KEYS)(
+    "stops matching when %s alone is changed",
+    (key) => {
+      const values: CursorMotionPresetValues = {
+        ...CURSOR_MOTION_PRESETS.focused.values,
+      };
+      const current = values[key];
+      // Perturb whichever kind of value this key holds.
+      (values as unknown as Record<string, unknown>)[key] =
+        typeof current === "number" ? current + 0.123 : "linear";
+
+      expect(getMatchingCursorMotionPresetId(values)).toBeNull();
+    },
+  );
+
+  it("returns null for values that are not a preset", () => {
+    expect(
+      getMatchingCursorMotionPresetId({
+        ...CURSOR_MOTION_PRESETS.focused.values,
+        cursorSize: 9.9,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveCursorMotionPresetId", () => {
+  it("falls back when nothing matches", () => {
+    expect(
+      resolveCursorMotionPresetId({
+        ...CURSOR_MOTION_PRESETS.smooth.values,
+        cursorSize: 9.9,
+      }),
+    ).toBe("focused");
+  });
+
+  it("prefers an exact match over the fallback", () => {
+    expect(resolveCursorMotionPresetId(CURSOR_MOTION_PRESETS.smooth.values)).toBe(
+      "smooth",
+    );
+  });
+});

--- a/apps/desktop/src/components/editor/utils/cursor-motion-presets.ts
+++ b/apps/desktop/src/components/editor/utils/cursor-motion-presets.ts
@@ -1,16 +1,31 @@
 import {
   DEFAULT_ZOOM_IN_DURATION_MS,
   DEFAULT_ZOOM_OUT_DURATION_MS,
+  type ZoomTransitionEasing,
 } from "@/types/editor";
 
 export type CursorMotionPresetId = "focused" | "smooth";
 
-export interface CursorMotionPreset {
-  id: CursorMotionPresetId;
-  label: string;
+/**
+ * Every setting a motion preset writes.
+ *
+ * The matcher iterates these keys and the apply path requires a handler for
+ * each, so adding a field here is a compile error until it is wired to a
+ * control — which is what stops a preset from becoming the only way to reach a
+ * value (roadmap D2: presets are starting points, not replacements).
+ */
+export interface CursorMotionPresetValues {
+  // Camera
   zoomSmoothness: number;
+  cameraSpringStiffnessMultiplier: number;
+  cameraSpringDampingMultiplier: number;
+  cameraSpringMassMultiplier: number;
   zoomInDurationMs: number;
   zoomOutDurationMs: number;
+  zoomInEasing: ZoomTransitionEasing;
+  zoomOutEasing: ZoomTransitionEasing;
+  connectedZoomEasing: ZoomTransitionEasing;
+  // Cursor
   cursorSize: number;
   cursorSmoothing: number;
   cursorSpringStiffnessMultiplier: number;
@@ -21,17 +36,10 @@ export interface CursorMotionPreset {
   cursorClickBounceDuration: number;
 }
 
-export interface CursorMotionPresetSelectionInput {
-  zoomInDurationMs: number;
-  zoomOutDurationMs: number;
-  cursorSize: number;
-  cursorSmoothing: number;
-  cursorSpringStiffnessMultiplier: number;
-  cursorSpringDampingMultiplier: number;
-  cursorSpringMassMultiplier: number;
-  cursorMotionBlur: number;
-  cursorClickBounce: number;
-  cursorClickBounceDuration: number;
+export interface CursorMotionPreset {
+  id: CursorMotionPresetId;
+  label: string;
+  values: CursorMotionPresetValues;
 }
 
 const SHARED_CURSOR_PRESET_VALUES = {
@@ -50,46 +58,62 @@ export const CURSOR_MOTION_PRESETS: Record<
   focused: {
     id: "focused",
     label: "Focused",
-    zoomSmoothness: 0.5,
-    zoomInDurationMs: 200,
-    zoomOutDurationMs: 200,
-    ...SHARED_CURSOR_PRESET_VALUES,
-    cursorSpringStiffnessMultiplier: 1.35,
-    cursorSpringDampingMultiplier: 0.79,
+    values: {
+      ...SHARED_CURSOR_PRESET_VALUES,
+      // Tighter, quicker camera: arrives and settles.
+      zoomSmoothness: 0.35,
+      cameraSpringStiffnessMultiplier: 1.2,
+      cameraSpringDampingMultiplier: 0.95,
+      cameraSpringMassMultiplier: 0.95,
+      zoomInDurationMs: 200,
+      zoomOutDurationMs: 200,
+      zoomInEasing: "snappy",
+      zoomOutEasing: "quiro",
+      connectedZoomEasing: "glide",
+      cursorSpringStiffnessMultiplier: 1.35,
+      cursorSpringDampingMultiplier: 0.79,
+    },
   },
   smooth: {
     id: "smooth",
     label: "Smooth",
-    zoomSmoothness: 0.5,
-    zoomInDurationMs: DEFAULT_ZOOM_IN_DURATION_MS,
-    zoomOutDurationMs: DEFAULT_ZOOM_OUT_DURATION_MS,
-    ...SHARED_CURSOR_PRESET_VALUES,
-    cursorSpringStiffnessMultiplier: 0.92,
-    cursorSpringDampingMultiplier: 1.36,
+    values: {
+      ...SHARED_CURSOR_PRESET_VALUES,
+      // Looser, heavier camera: glides and coasts.
+      zoomSmoothness: 0.7,
+      cameraSpringStiffnessMultiplier: 0.85,
+      cameraSpringDampingMultiplier: 1.3,
+      cameraSpringMassMultiplier: 1.3,
+      zoomInDurationMs: DEFAULT_ZOOM_IN_DURATION_MS,
+      zoomOutDurationMs: DEFAULT_ZOOM_OUT_DURATION_MS,
+      zoomInEasing: "smooth",
+      zoomOutEasing: "smooth",
+      connectedZoomEasing: "glide",
+      cursorSpringStiffnessMultiplier: 0.92,
+      cursorSpringDampingMultiplier: 1.36,
+    },
   },
 };
 
+export const CURSOR_MOTION_PRESET_IDS = Object.keys(
+  CURSOR_MOTION_PRESETS,
+) as CursorMotionPresetId[];
+
+export const CURSOR_MOTION_PRESET_KEYS = Object.keys(
+  CURSOR_MOTION_PRESETS.focused.values,
+) as (keyof CursorMotionPresetValues)[];
+
 export function getMatchingCursorMotionPresetId(
-  values: CursorMotionPresetSelectionInput,
+  values: CursorMotionPresetValues,
 ): CursorMotionPresetId | null {
-  for (const presetId of Object.keys(
-    CURSOR_MOTION_PRESETS,
-  ) as CursorMotionPresetId[]) {
+  for (const presetId of CURSOR_MOTION_PRESET_IDS) {
     const preset = CURSOR_MOTION_PRESETS[presetId];
-    if (
-      preset.zoomInDurationMs === values.zoomInDurationMs &&
-      preset.zoomOutDurationMs === values.zoomOutDurationMs &&
-      preset.cursorSize === values.cursorSize &&
-      preset.cursorSmoothing === values.cursorSmoothing &&
-      preset.cursorSpringStiffnessMultiplier ===
-        values.cursorSpringStiffnessMultiplier &&
-      preset.cursorSpringDampingMultiplier ===
-        values.cursorSpringDampingMultiplier &&
-      preset.cursorSpringMassMultiplier === values.cursorSpringMassMultiplier &&
-      preset.cursorMotionBlur === values.cursorMotionBlur &&
-      preset.cursorClickBounce === values.cursorClickBounce &&
-      preset.cursorClickBounceDuration === values.cursorClickBounceDuration
-    ) {
+    // Every declared key is compared. A preset that writes a field the matcher
+    // ignored would keep showing as active after the user edited away from it.
+    const matches = CURSOR_MOTION_PRESET_KEYS.every(
+      (key) => preset.values[key] === values[key],
+    );
+    if (matches) {
       return presetId;
     }
   }
@@ -98,8 +122,33 @@ export function getMatchingCursorMotionPresetId(
 }
 
 export function resolveCursorMotionPresetId(
-  values: CursorMotionPresetSelectionInput,
+  values: CursorMotionPresetValues,
   fallback: CursorMotionPresetId = "focused",
 ): CursorMotionPresetId {
   return getMatchingCursorMotionPresetId(values) ?? fallback;
+}
+
+/**
+ * A setter per preset field. Required, not optional — adding a field to
+ * `CursorMotionPresetValues` without wiring a control here will not compile.
+ */
+export type CursorMotionPresetHandlers = {
+  [K in keyof CursorMotionPresetValues]: (
+    value: CursorMotionPresetValues[K],
+  ) => void;
+};
+
+export function applyCursorMotionPreset(
+  presetId: CursorMotionPresetId,
+  handlers: CursorMotionPresetHandlers,
+) {
+  const { values } = CURSOR_MOTION_PRESETS[presetId];
+  // Generic so the handler and the value stay correlated per key; a cast
+  // here would widen both sides and let a curve name reach a number setter.
+  const write = <K extends keyof CursorMotionPresetValues>(key: K) => {
+    handlers[key](values[key]);
+  };
+  for (const key of CURSOR_MOTION_PRESET_KEYS) {
+    write(key);
+  }
 }

--- a/apps/desktop/src/components/editor/utils/editor-preferences.ts
+++ b/apps/desktop/src/components/editor/utils/editor-preferences.ts
@@ -3,6 +3,7 @@ import {
   normalizeExportMp4FrameRate,
   normalizeExportPipelineModel,
   normalizeProjectEditor,
+  normalizeZoomTransitionEasing,
   type ProjectEditorState,
 } from "./project-persistance";
 import {
@@ -325,10 +326,20 @@ function normalizeEditorControls(
     connectedZoomGapMs: raw.connectedZoomGapMs ?? fallback.connectedZoomGapMs,
     connectedZoomDurationMs:
       raw.connectedZoomDurationMs ?? fallback.connectedZoomDurationMs,
-    zoomInEasing: raw.zoomInEasing ?? fallback.zoomInEasing,
-    zoomOutEasing: raw.zoomOutEasing ?? fallback.zoomOutEasing,
-    connectedZoomEasing:
-      raw.connectedZoomEasing ?? fallback.connectedZoomEasing,
+    // Validated rather than passed through: preferences are untrusted JSON, and
+    // these values are now read every frame by the camera.
+    zoomInEasing: normalizeZoomTransitionEasing(
+      raw.zoomInEasing,
+      fallback.zoomInEasing,
+    ),
+    zoomOutEasing: normalizeZoomTransitionEasing(
+      raw.zoomOutEasing,
+      fallback.zoomOutEasing,
+    ),
+    connectedZoomEasing: normalizeZoomTransitionEasing(
+      raw.connectedZoomEasing,
+      fallback.connectedZoomEasing,
+    ),
     showCursor: raw.showCursor ?? fallback.showCursor,
     loopCursor: raw.loopCursor ?? fallback.loopCursor,
     cursorStyle: raw.cursorStyle ?? fallback.cursorStyle,

--- a/apps/desktop/src/components/editor/utils/editor-preferences.ts
+++ b/apps/desktop/src/components/editor/utils/editor-preferences.ts
@@ -18,6 +18,7 @@ type PersistedEditorControls = Pick<
   | "shadowIntensity"
   | "backgroundBlur"
   | "zoomMotionBlur"
+  | "zoomDrift"
   | "zoomMotionBlurTuning"
   | "zoomTemporalMotionBlur"
   | "zoomMotionBlurSampleCount"
@@ -101,6 +102,7 @@ export const DEFAULT_EDITOR_PREFERENCES: EditorPreferences = {
   shadowIntensity: DEFAULT_EDITOR_CONTROLS.shadowIntensity,
   backgroundBlur: DEFAULT_EDITOR_CONTROLS.backgroundBlur,
   zoomMotionBlur: DEFAULT_EDITOR_CONTROLS.zoomMotionBlur,
+  zoomDrift: DEFAULT_EDITOR_CONTROLS.zoomDrift,
   zoomMotionBlurTuning: DEFAULT_EDITOR_CONTROLS.zoomMotionBlurTuning,
   zoomTemporalMotionBlur: DEFAULT_EDITOR_CONTROLS.zoomTemporalMotionBlur,
   zoomMotionBlurSampleCount: DEFAULT_EDITOR_CONTROLS.zoomMotionBlurSampleCount,
@@ -310,6 +312,7 @@ function normalizeEditorControls(
     shadowIntensity: raw.shadowIntensity ?? fallback.shadowIntensity,
     backgroundBlur: raw.backgroundBlur ?? fallback.backgroundBlur,
     zoomMotionBlur: raw.zoomMotionBlur ?? fallback.zoomMotionBlur,
+    zoomDrift: raw.zoomDrift ?? fallback.zoomDrift,
     zoomMotionBlurTuning:
       raw.zoomMotionBlurTuning ?? fallback.zoomMotionBlurTuning,
     zoomTemporalMotionBlur:
@@ -399,6 +402,7 @@ function normalizeEditorControls(
     shadowIntensity: normalized.shadowIntensity,
     backgroundBlur: normalized.backgroundBlur,
     zoomMotionBlur: normalized.zoomMotionBlur,
+    zoomDrift: normalized.zoomDrift,
     zoomMotionBlurTuning: normalized.zoomMotionBlurTuning,
     zoomTemporalMotionBlur: normalized.zoomTemporalMotionBlur,
     zoomMotionBlurSampleCount: normalized.zoomMotionBlurSampleCount,

--- a/apps/desktop/src/components/editor/utils/project-persistance.test.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ZoomRegion } from "@/types/editor";
 import {
   normalizeProjectEditor,
   normalizeProjectSnapshots,
@@ -80,5 +81,36 @@ describe("project persistence normalization", () => {
     expect(toFileUrl("C:\\Recordings\\clip 1.mp4")).toBe(
       "file:///C:/Recordings/clip%201.mp4",
     );
+  });
+});
+
+describe("normalizeProjectEditor — instant zoom", () => {
+  const region: ZoomRegion = {
+    id: "z1",
+    startMs: 1000,
+    endMs: 4000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+  };
+
+  it("defaults instant to off for projects saved before the flag existed", () => {
+    const [normalized] = normalizeProjectEditor({
+      zoomRegions: [region],
+    }).zoomRegions;
+    expect(normalized.instant).toBe(false);
+  });
+
+  it("round-trips an instant zoom", () => {
+    const [normalized] = normalizeProjectEditor({
+      zoomRegions: [{ ...region, instant: true }],
+    }).zoomRegions;
+    expect(normalized.instant).toBe(true);
+  });
+
+  it("coerces a non-boolean instant value to off rather than trusting it", () => {
+    const [normalized] = normalizeProjectEditor({
+      zoomRegions: [{ ...region, instant: "yes" as unknown as boolean }],
+    }).zoomRegions;
+    expect(normalized.instant).toBe(false);
   });
 });

--- a/apps/desktop/src/components/editor/utils/project-persistance.test.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.test.ts
@@ -133,3 +133,56 @@ describe("normalizeProjectEditor — zoom drift", () => {
     ).toBe(0);
   });
 });
+
+describe("normalizeProjectEditor — motion values are the user's, not a preset's", () => {
+  // Loading a project used to resolve the closest motion preset and then
+  // overwrite ten stored fields with that preset's values, so any custom
+  // tuning silently snapped back to Focused on reopen.
+  const custom = {
+    cursorSize: 4.2,
+    cursorSmoothing: 1.1,
+    cursorSpringStiffnessMultiplier: 2.4,
+    cursorSpringDampingMultiplier: 0.4,
+    cursorSpringMassMultiplier: 2.1,
+    cursorMotionBlur: 1.7,
+    cursorClickBounce: 4.4,
+    cursorClickBounceDuration: 420,
+    zoomInDurationMs: 640,
+    zoomOutDurationMs: 880,
+  };
+
+  it("keeps every custom motion value through a load", () => {
+    const normalized = normalizeProjectEditor(custom);
+    for (const [key, value] of Object.entries(custom)) {
+      expect([key, normalized[key as keyof typeof custom]]).toEqual([
+        key,
+        value,
+      ]);
+    }
+  });
+
+  it("still clamps values that are out of range", () => {
+    expect(normalizeProjectEditor({ cursorSize: 999 }).cursorSize).toBe(10);
+  });
+
+  it("still falls back for values that are absent", () => {
+    const normalized = normalizeProjectEditor({});
+    expect(Number.isFinite(normalized.cursorSize)).toBe(true);
+    expect(Number.isFinite(normalized.zoomInDurationMs)).toBe(true);
+  });
+});
+
+describe("normalizeProjectEditor — zoom smoothness", () => {
+  // Was hardcoded to the default on load, so whatever a motion preset wrote
+  // snapped back to 0.5 on reopen.
+  it("keeps a stored value", () => {
+    expect(normalizeProjectEditor({ zoomSmoothness: 0.7 }).zoomSmoothness).toBe(
+      0.7,
+    );
+  });
+
+  it("clamps and falls back", () => {
+    expect(normalizeProjectEditor({ zoomSmoothness: 5 }).zoomSmoothness).toBe(1);
+    expect(normalizeProjectEditor({}).zoomSmoothness).toBe(0.5);
+  });
+});

--- a/apps/desktop/src/components/editor/utils/project-persistance.test.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.test.ts
@@ -186,3 +186,62 @@ describe("normalizeProjectEditor — zoom smoothness", () => {
     expect(normalizeProjectEditor({}).zoomSmoothness).toBe(0.5);
   });
 });
+
+describe("normalizeProjectEditor — #30 legacy default migration", () => {
+  // No settings-panel control for these three has ever existed, so a stored
+  // value that exactly matches the OLD shipped default is definitionally
+  // "whatever the build shipped," not a deliberate choice — safe to remap to
+  // the value already in force so existing projects keep today's motion.
+
+  it("remaps a stored 500ms overlap (the old default) to 1000ms", () => {
+    expect(
+      normalizeProjectEditor({ zoomInOverlapMs: 500, zoomInDurationMs: 2000 })
+        .zoomInOverlapMs,
+    ).toBe(1000);
+  });
+
+  it("remaps a stored 1500ms gap (the old default) to 1350ms", () => {
+    expect(
+      normalizeProjectEditor({ connectedZoomGapMs: 1500 }).connectedZoomGapMs,
+    ).toBe(1350);
+  });
+
+  it("leaves a deliberately different stored value alone", () => {
+    // Only the exact legacy sentinel is remapped; anything else is a value
+    // some other code path already understood.
+    expect(
+      normalizeProjectEditor({ zoomInOverlapMs: 750, zoomInDurationMs: 2000 })
+        .zoomInOverlapMs,
+    ).toBe(750);
+    expect(
+      normalizeProjectEditor({ connectedZoomGapMs: 900 }).connectedZoomGapMs,
+    ).toBe(900);
+  });
+
+  it("defaults to the value already in force for a project missing the field", () => {
+    expect(normalizeProjectEditor({}).zoomInOverlapMs).toBe(1000);
+    expect(normalizeProjectEditor({}).connectedZoomGapMs).toBe(1350);
+    expect(normalizeProjectEditor({}).connectedZoomDurationMs).toBe(1000);
+  });
+
+  it("still clamps a remapped overlap to the zoom-in duration", () => {
+    // 1000 > a 400ms zoom-in duration, so the clamp still has to apply after
+    // the remap, not instead of it.
+    expect(
+      normalizeProjectEditor({ zoomInOverlapMs: 500, zoomInDurationMs: 400 })
+        .zoomInOverlapMs,
+    ).toBe(400);
+  });
+
+  it("round-trips a non-legacy overlap and gap through save and load", () => {
+    const normalized = normalizeProjectEditor({
+      zoomInOverlapMs: 620,
+      zoomInDurationMs: 2000,
+      connectedZoomGapMs: 800,
+      connectedZoomDurationMs: 1400,
+    });
+    expect(normalized.zoomInOverlapMs).toBe(620);
+    expect(normalized.connectedZoomGapMs).toBe(800);
+    expect(normalized.connectedZoomDurationMs).toBe(1400);
+  });
+});

--- a/apps/desktop/src/components/editor/utils/project-persistance.test.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.test.ts
@@ -114,3 +114,22 @@ describe("normalizeProjectEditor — instant zoom", () => {
     expect(normalized.instant).toBe(false);
   });
 });
+
+describe("normalizeProjectEditor — zoom drift", () => {
+  it("defaults to off for projects saved before drift existed", () => {
+    expect(normalizeProjectEditor({}).zoomDrift).toBe(0);
+  });
+
+  it("round-trips a drift strength", () => {
+    expect(normalizeProjectEditor({ zoomDrift: 0.6 }).zoomDrift).toBe(0.6);
+  });
+
+  it("clamps out-of-range values rather than trusting the file", () => {
+    expect(normalizeProjectEditor({ zoomDrift: 9 }).zoomDrift).toBe(1);
+    expect(normalizeProjectEditor({ zoomDrift: -3 }).zoomDrift).toBe(0);
+    expect(
+      normalizeProjectEditor({ zoomDrift: "lots" as unknown as number })
+        .zoomDrift,
+    ).toBe(0);
+  });
+});

--- a/apps/desktop/src/components/editor/utils/project-persistance.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.ts
@@ -70,6 +70,7 @@ import {
   DEFAULT_ZOOM_DEPTH,
   DEFAULT_ZOOM_IN_EASING,
   DEFAULT_ZOOM_IN_OVERLAP_MS,
+  DEFAULT_ZOOM_DRIFT,
   DEFAULT_ZOOM_MOTION_BLUR,
   DEFAULT_ZOOM_MOTION_BLUR_TUNING,
   DEFAULT_ZOOM_OUT_EASING,
@@ -98,6 +99,7 @@ export interface ProjectEditorState {
   shadowIntensity: number;
   backgroundBlur: number;
   zoomMotionBlur: number;
+  zoomDrift: number;
   zoomMotionBlurTuning: ZoomMotionBlurTuning;
   zoomTemporalMotionBlur: number;
   zoomMotionBlurSampleCount: number | null;
@@ -1214,6 +1216,11 @@ export function normalizeProjectEditor(
         : 0.67,
     backgroundBlur: normalizedBackgroundBlur,
     zoomMotionBlur: normalizedZoomMotionBlur,
+    zoomDrift: isFiniteNumber(
+      (editor as Partial<ProjectEditorState>).zoomDrift,
+    )
+      ? clamp((editor as Partial<ProjectEditorState>).zoomDrift as number, 0, 1)
+      : DEFAULT_ZOOM_DRIFT,
     zoomMotionBlurTuning: normalizedZoomMotionBlurTuning,
     zoomTemporalMotionBlur: normalizedZoomTemporalMotionBlur,
     zoomMotionBlurSampleCount: normalizedZoomMotionBlurSampleCount,

--- a/apps/desktop/src/components/editor/utils/project-persistance.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.ts
@@ -730,6 +730,7 @@ export function normalizeProjectEditor(
                 : undefined,
             enabled:
               typeof region.enabled === "boolean" ? region.enabled : true,
+            instant: region.instant === true,
             presetId: normalizeZoomPresetId(region.presetId),
             endFocus: region.endFocus
               ? {

--- a/apps/desktop/src/components/editor/utils/project-persistance.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.ts
@@ -23,10 +23,7 @@ import {
   type AspectRatio,
   isCustomAspectRatio,
 } from "@electron/utils/aspectRatioUtils";
-import {
-  CURSOR_MOTION_PRESETS,
-  resolveCursorMotionPresetId,
-} from "./cursor-motion-presets";
+import { CURSOR_MOTION_PRESETS } from "./cursor-motion-presets";
 import {
   type AnnotationRegion,
   type AnnotationKeyframe,
@@ -675,13 +672,13 @@ export function normalizeProjectEditor(
     : TEMPORAL_MOTION_BLUR_DEFAULT_SHUTTER_FRACTION;
   const normalizedZoomInDurationMs = isFiniteNumber(editor.zoomInDurationMs)
     ? clamp(editor.zoomInDurationMs, 60, 4000)
-    : DEFAULT_MOTION_PRESET.zoomInDurationMs;
+    : DEFAULT_MOTION_PRESET.values.zoomInDurationMs;
   const normalizedZoomInOverlapMs = isFiniteNumber(editor.zoomInOverlapMs)
     ? clamp(editor.zoomInOverlapMs, 0, normalizedZoomInDurationMs)
     : DEFAULT_ZOOM_IN_OVERLAP_MS;
   const normalizedZoomOutDurationMs = isFiniteNumber(editor.zoomOutDurationMs)
     ? clamp(editor.zoomOutDurationMs, 60, 4000)
-    : DEFAULT_MOTION_PRESET.zoomOutDurationMs;
+    : DEFAULT_MOTION_PRESET.values.zoomOutDurationMs;
   const normalizedConnectedZoomGapMs = isFiniteNumber(editor.connectedZoomGapMs)
     ? clamp(editor.connectedZoomGapMs, 0, 5000)
     : DEFAULT_CONNECTED_ZOOM_GAP_MS;
@@ -1154,25 +1151,25 @@ export function normalizeProjectEditor(
     zoomOutDurationMs: normalizedZoomOutDurationMs,
     cursorSize: isFiniteNumber(editor.cursorSize)
       ? clamp(editor.cursorSize, 0.5, 10)
-      : DEFAULT_MOTION_PRESET.cursorSize,
+      : DEFAULT_MOTION_PRESET.values.cursorSize,
     cursorSmoothing: isFiniteNumber(editor.cursorSmoothing)
       ? clamp(editor.cursorSmoothing, 0, 2)
-      : DEFAULT_MOTION_PRESET.cursorSmoothing,
+      : DEFAULT_MOTION_PRESET.values.cursorSmoothing,
     cursorSpringStiffnessMultiplier: isFiniteNumber(
       editor.cursorSpringStiffnessMultiplier,
     )
       ? clamp(editor.cursorSpringStiffnessMultiplier, 0.25, 3)
-      : DEFAULT_MOTION_PRESET.cursorSpringStiffnessMultiplier,
+      : DEFAULT_MOTION_PRESET.values.cursorSpringStiffnessMultiplier,
     cursorSpringDampingMultiplier: isFiniteNumber(
       editor.cursorSpringDampingMultiplier,
     )
       ? clamp(editor.cursorSpringDampingMultiplier, 0.25, 3)
-      : DEFAULT_MOTION_PRESET.cursorSpringDampingMultiplier,
+      : DEFAULT_MOTION_PRESET.values.cursorSpringDampingMultiplier,
     cursorSpringMassMultiplier: isFiniteNumber(
       editor.cursorSpringMassMultiplier,
     )
       ? clamp(editor.cursorSpringMassMultiplier, 0.25, 3)
-      : DEFAULT_MOTION_PRESET.cursorSpringMassMultiplier,
+      : DEFAULT_MOTION_PRESET.values.cursorSpringMassMultiplier,
     cursorMotionBlur: isFiniteNumber(
       (editor as Partial<ProjectEditorState>).cursorMotionBlur,
     )
@@ -1181,7 +1178,7 @@ export function normalizeProjectEditor(
           0,
           2,
         )
-      : DEFAULT_MOTION_PRESET.cursorMotionBlur,
+      : DEFAULT_MOTION_PRESET.values.cursorMotionBlur,
     cursorClickBounce: isFiniteNumber(
       (editor as Partial<ProjectEditorState>).cursorClickBounce,
     )
@@ -1190,7 +1187,7 @@ export function normalizeProjectEditor(
           0,
           5,
         )
-      : DEFAULT_MOTION_PRESET.cursorClickBounce,
+      : DEFAULT_MOTION_PRESET.values.cursorClickBounce,
     cursorClickBounceDuration: isFiniteNumber(
       (editor as Partial<ProjectEditorState>).cursorClickBounceDuration,
     )
@@ -1200,10 +1197,8 @@ export function normalizeProjectEditor(
           60,
           500,
         )
-      : DEFAULT_MOTION_PRESET.cursorClickBounceDuration,
+      : DEFAULT_MOTION_PRESET.values.cursorClickBounceDuration,
   };
-  const normalizedMotionPreset =
-    CURSOR_MOTION_PRESETS[resolveCursorMotionPresetId(normalizedMotionValues)];
 
   return {
     wallpaper:
@@ -1227,9 +1222,9 @@ export function normalizeProjectEditor(
     zoomMotionBlurShutterFraction: normalizedZoomMotionBlurShutterFraction,
     connectZooms:
       typeof editor.connectZooms === "boolean" ? editor.connectZooms : true,
-    zoomInDurationMs: normalizedMotionPreset.zoomInDurationMs,
+    zoomInDurationMs: normalizedMotionValues.zoomInDurationMs,
     zoomInOverlapMs: normalizedZoomInOverlapMs,
-    zoomOutDurationMs: normalizedMotionPreset.zoomOutDurationMs,
+    zoomOutDurationMs: normalizedMotionValues.zoomOutDurationMs,
     connectedZoomGapMs: normalizedConnectedZoomGapMs,
     connectedZoomDurationMs: normalizedConnectedZoomDurationMs,
     zoomInEasing: normalizeZoomTransitionEasing(
@@ -1249,14 +1244,14 @@ export function normalizeProjectEditor(
     loopCursor:
       typeof editor.loopCursor === "boolean" ? editor.loopCursor : false,
     cursorStyle: normalizedCursorStyle,
-    cursorSize: normalizedMotionPreset.cursorSize,
-    cursorSmoothing: normalizedMotionPreset.cursorSmoothing,
+    cursorSize: normalizedMotionValues.cursorSize,
+    cursorSmoothing: normalizedMotionValues.cursorSmoothing,
     cursorSpringStiffnessMultiplier:
-      normalizedMotionPreset.cursorSpringStiffnessMultiplier,
+      normalizedMotionValues.cursorSpringStiffnessMultiplier,
     cursorSpringDampingMultiplier:
-      normalizedMotionPreset.cursorSpringDampingMultiplier,
+      normalizedMotionValues.cursorSpringDampingMultiplier,
     cursorSpringMassMultiplier:
-      normalizedMotionPreset.cursorSpringMassMultiplier,
+      normalizedMotionValues.cursorSpringMassMultiplier,
     cameraSpringStiffnessMultiplier: isFiniteNumber(
       editor.cameraSpringStiffnessMultiplier,
     )
@@ -1272,14 +1267,16 @@ export function normalizeProjectEditor(
     )
       ? clamp(editor.cameraSpringMassMultiplier, 0.25, 3)
       : 1.12,
-    zoomSmoothness: DEFAULT_ZOOM_SMOOTHNESS,
+    zoomSmoothness: isFiniteNumber(editor.zoomSmoothness)
+      ? clamp(editor.zoomSmoothness, 0, 1)
+      : DEFAULT_ZOOM_SMOOTHNESS,
     zoomClassicMode:
       typeof editor.zoomClassicMode === "boolean"
         ? editor.zoomClassicMode
         : false,
-    cursorMotionBlur: normalizedMotionPreset.cursorMotionBlur,
-    cursorClickBounce: normalizedMotionPreset.cursorClickBounce,
-    cursorClickBounceDuration: normalizedMotionPreset.cursorClickBounceDuration,
+    cursorMotionBlur: normalizedMotionValues.cursorMotionBlur,
+    cursorClickBounce: normalizedMotionValues.cursorClickBounce,
+    cursorClickBounceDuration: normalizedMotionValues.cursorClickBounceDuration,
     cursorClickEffect: normalizeCursorClickEffect(editor.cursorClickEffect),
     cursorSway: isFiniteNumber(
       (editor as Partial<ProjectEditorState>).cursorSway,

--- a/apps/desktop/src/components/editor/utils/project-persistance.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.ts
@@ -411,7 +411,7 @@ export function normalizeExportMp4FrameRate(
   return typeof value === "number" && isValidMp4FrameRate(value) ? value : 30;
 }
 
-function normalizeZoomTransitionEasing(
+export function normalizeZoomTransitionEasing(
   value: unknown,
   fallback: ZoomTransitionEasing,
 ): ZoomTransitionEasing {

--- a/apps/desktop/src/components/editor/utils/project-persistance.ts
+++ b/apps/desktop/src/components/editor/utils/project-persistance.ts
@@ -182,6 +182,25 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
+// #30 — zoomInOverlapMs and connectedZoomGapMs were persisted but never read;
+// the module constants that actually ran disagreed with the shipped
+// defaults below. No settings-panel control for either has ever existed, so
+// every stored value is definitionally "whatever this build shipped" — never
+// a deliberate user choice. A file that recorded exactly the stale default
+// is therefore safe to remap to the new one on load; anything else is a
+// value that was written by code that already knew what it meant (a preset,
+// or this same normaliser on a later save) and is passed through unchanged.
+const LEGACY_DEFAULT_ZOOM_IN_OVERLAP_MS = 500;
+const LEGACY_DEFAULT_CONNECTED_ZOOM_GAP_MS = 1500;
+
+function remapLegacyDefault(
+  value: number,
+  legacyDefault: number,
+  currentDefault: number,
+) {
+  return value === legacyDefault ? currentDefault : value;
+}
+
 function normalizeZoomPresetId(value: unknown): ZoomPresetId | undefined {
   return value === "focus" ||
     value === "follow-cursor" ||
@@ -674,13 +693,29 @@ export function normalizeProjectEditor(
     ? clamp(editor.zoomInDurationMs, 60, 4000)
     : DEFAULT_MOTION_PRESET.values.zoomInDurationMs;
   const normalizedZoomInOverlapMs = isFiniteNumber(editor.zoomInOverlapMs)
-    ? clamp(editor.zoomInOverlapMs, 0, normalizedZoomInDurationMs)
+    ? clamp(
+        remapLegacyDefault(
+          editor.zoomInOverlapMs,
+          LEGACY_DEFAULT_ZOOM_IN_OVERLAP_MS,
+          DEFAULT_ZOOM_IN_OVERLAP_MS,
+        ),
+        0,
+        normalizedZoomInDurationMs,
+      )
     : DEFAULT_ZOOM_IN_OVERLAP_MS;
   const normalizedZoomOutDurationMs = isFiniteNumber(editor.zoomOutDurationMs)
     ? clamp(editor.zoomOutDurationMs, 60, 4000)
     : DEFAULT_MOTION_PRESET.values.zoomOutDurationMs;
   const normalizedConnectedZoomGapMs = isFiniteNumber(editor.connectedZoomGapMs)
-    ? clamp(editor.connectedZoomGapMs, 0, 5000)
+    ? clamp(
+        remapLegacyDefault(
+          editor.connectedZoomGapMs,
+          LEGACY_DEFAULT_CONNECTED_ZOOM_GAP_MS,
+          DEFAULT_CONNECTED_ZOOM_GAP_MS,
+        ),
+        0,
+        5000,
+      )
     : DEFAULT_CONNECTED_ZOOM_GAP_MS;
   const normalizedConnectedZoomDurationMs = isFiniteNumber(
     editor.connectedZoomDurationMs,

--- a/apps/desktop/src/components/editor/videoPlayback/cursorFollowCamera.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/cursorFollowCamera.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { ZOOM_DEPTH_SCALES } from "@/types/editor";
 import {
 	computeCursorFollowFocus,
 	createCursorFollowCameraState,
+	SNAP_TO_EDGES_RATIO_AUTO,
 } from "./cursorFollowCamera";
 
 describe("computeCursorFollowFocus", () => {
@@ -106,5 +108,150 @@ describe("computeCursorFollowFocus", () => {
 		);
 
 		expect(clampedFocus).toEqual({ cx: 0.75, cy: 0.75 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Edge behaviour across every zoom depth (#20)
+//
+// The camera holds a persistent centre and only recenters once the cursor
+// leaves an inner safe zone. The safe zone is expressed as a fraction of the
+// *visible* span, so the question this suite answers is whether that produces
+// the same feel at 1.25x as at 5x.
+// ---------------------------------------------------------------------------
+
+const DEPTH_SCALES = Object.values(ZOOM_DEPTH_SCALES);
+// The shipped ratio, plus a deliberately different one: the uniformity
+// property must hold for any ratio, not just the value we happen to ship.
+const SNAP_RATIOS = [SNAP_TO_EDGES_RATIO_AUTO, 0.4];
+
+function follow(
+	zoomScale: number,
+	snapToEdgesRatio: number,
+	cursor: { cx: number; cy: number },
+	startFocus = { cx: 0.5, cy: 0.5 },
+) {
+	const state = createCursorFollowCameraState();
+	const samples = [
+		{ timeMs: 0, cx: startFocus.cx, cy: startFocus.cy, interactionType: "move" as const },
+		{ timeMs: 100, cx: cursor.cx, cy: cursor.cy, interactionType: "move" as const },
+	];
+	computeCursorFollowFocus(state, samples, 0, zoomScale, 1, startFocus, {
+		snapToEdgesRatio,
+	});
+	return computeCursorFollowFocus(state, samples, 100, zoomScale, 1, startFocus, {
+		snapToEdgesRatio,
+	});
+}
+
+function marginFor(zoomScale: number) {
+	return 1 / (2 * zoomScale);
+}
+
+describe.each(SNAP_RATIOS)("edge pinning at snap ratio %s", (ratio) => {
+	it.each(DEPTH_SCALES)("pins to every edge at zoom scale %s", (zoomScale) => {
+		const margin = marginFor(zoomScale);
+
+		const left = follow(zoomScale, ratio, { cx: 0, cy: 0.5 });
+		expect(left.cx).toBeCloseTo(margin, 6);
+
+		const right = follow(zoomScale, ratio, { cx: 1, cy: 0.5 });
+		expect(right.cx).toBeCloseTo(1 - margin, 6);
+
+		const top = follow(zoomScale, ratio, { cx: 0.5, cy: 0 });
+		expect(top.cy).toBeCloseTo(margin, 6);
+
+		const bottom = follow(zoomScale, ratio, { cx: 0.5, cy: 1 });
+		expect(bottom.cy).toBeCloseTo(1 - margin, 6);
+	});
+
+	it.each(DEPTH_SCALES)(
+		"never lets the frame leave the video at zoom scale %s",
+		(zoomScale) => {
+			const margin = marginFor(zoomScale);
+			for (let c = 0; c <= 1.0001; c += 0.02) {
+				const focus = follow(zoomScale, ratio, { cx: c, cy: c });
+				expect(focus.cx).toBeGreaterThanOrEqual(margin - 1e-9);
+				expect(focus.cx).toBeLessThanOrEqual(1 - margin + 1e-9);
+				expect(focus.cy).toBeGreaterThanOrEqual(margin - 1e-9);
+				expect(focus.cy).toBeLessThanOrEqual(1 - margin + 1e-9);
+			}
+		},
+	);
+
+	it.each(DEPTH_SCALES)(
+		"holds the camera still inside the safe zone at zoom scale %s",
+		(zoomScale) => {
+			const halfSpan = 1 / (2 * zoomScale);
+			// Comfortably inside: the safe edge sits at halfSpan * (1 - 2 * ratio).
+			const inside = 0.5 + halfSpan * (1 - 2 * ratio) * 0.5;
+			expect(follow(zoomScale, ratio, { cx: inside, cy: 0.5 })).toEqual({
+				cx: 0.5,
+				cy: 0.5,
+			});
+		},
+	);
+});
+
+describe("safe zone uniformity across depths", () => {
+	// The claim under test: the camera starts moving at the same *proportion*
+	// of the visible span at every depth. If this drifted, a zoom would feel
+	// different at depth 1 than at depth 6 — the symptom #20 exists to catch.
+	it.each(SNAP_RATIOS)(
+		"starts moving at the same fraction of the visible span at ratio %s",
+		(ratio) => {
+			const fractions = DEPTH_SCALES.map((zoomScale) => {
+				const halfSpan = 1 / (2 * zoomScale);
+				// Walk the cursor out from the centre until the camera reacts.
+				let threshold = 0.5;
+				for (let step = 0; step <= 2000; step += 1) {
+					const cx = 0.5 + (step / 2000) * halfSpan;
+					if (follow(zoomScale, ratio, { cx, cy: 0.5 }).cx !== 0.5) {
+						threshold = cx;
+						break;
+					}
+				}
+				return (threshold - 0.5) / halfSpan;
+			});
+
+			for (const fraction of fractions) {
+				expect(fraction).toBeCloseTo(fractions[0], 2);
+			}
+			// And it is the documented fraction, not an accident.
+			expect(fractions[0]).toBeCloseTo(1 - 2 * ratio, 2);
+		},
+	);
+});
+
+describe.each(SNAP_RATIOS)("recenter target at snap ratio %s", (ratio) => {
+	// Pinning tests alone cannot tell "centre on the cursor" apart from
+	// "shift just enough to bring the cursor back inside the zone" — both clamp
+	// to the same value at an edge. This pins which one ships, so the tuning
+	// sweep changes it deliberately rather than by accident.
+	it("centres on the cursor once it leaves the zone", () => {
+		const exercised: number[] = [];
+
+		for (const zoomScale of DEPTH_SCALES) {
+			const halfSpan = 1 / (2 * zoomScale);
+			const margin = marginFor(zoomScale);
+			const safeRight = 0.5 + halfSpan * (1 - 2 * ratio);
+			const upperBound = 1 - margin;
+			// Shallow depths show so much of the frame that the bounds clamp
+			// starts before the safe zone ends; there the landing point is
+			// unobservable and the pinning tests already cover it.
+			if (safeRight >= upperBound) {
+				continue;
+			}
+
+			const cursorCx = (safeRight + upperBound) / 2;
+			expect([
+				zoomScale,
+				follow(zoomScale, ratio, { cx: cursorCx, cy: 0.5 }).cx,
+			]).toEqual([zoomScale, expect.closeTo(cursorCx, 6)]);
+			exercised.push(zoomScale);
+		}
+
+		// Guard against the loop skipping everything and passing vacuously.
+		expect(exercised.length).toBeGreaterThanOrEqual(3);
 	});
 });

--- a/apps/desktop/src/components/editor/videoPlayback/cursorFollowCamera.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/cursorFollowCamera.ts
@@ -7,12 +7,24 @@ import { clampFocusToScale } from "./focusUtils";
  *
  * Keeps a persistent camera center while zoomed in. The camera only recenters
  * after the cursor leaves an inner safe zone within the current zoomed view,
- * shifting just enough to bring the cursor back inside that zone.
+ * and then centres on the cursor before being clamped to the video bounds.
+ *
+ * The safe zone is a fraction of the *visible* span, so the camera reacts at
+ * the same proportional distance at every zoom depth — verified across all
+ * six in cursorFollowCamera.test.ts.
+ *
+ * Note: centring on the cursor is a stronger move than the minimum shift
+ * needed to bring it back inside the zone. That is a taste question for the
+ * tuning sweep, not a correctness bug — the framing is bounded either way.
  */
 
-/** Default snap ratio for manual zoom regions */
-export const SNAP_TO_EDGES_RATIO_MANUAL = 0.25;
-/** Snap ratio for system/auto zoom regions */
+/**
+ * How much of the visible span, at each edge, is outside the safe zone.
+ *
+ * One value for every zoom region. A separate manual-zoom ratio was
+ * declared but never referenced and held the same 0.25, so it was removed
+ * rather than left implying a distinction the product does not make.
+ */
 export const SNAP_TO_EDGES_RATIO_AUTO = 0.25;
 
 export interface CursorFollowCameraState {
@@ -35,8 +47,8 @@ export interface CursorFollowCameraState {
 
 export interface CursorFollowConfig {
   /**
-   * snapToEdgesRatio — how much of the screen edge pins the camera.
-   * 0.25 for manual zooms, 0.25 for auto/system zooms.
+   * snapToEdgesRatio — the fraction of the visible span, at each edge, that
+   * sits outside the safe zone. One value for every zoom region.
    */
   snapToEdgesRatio: number;
 }

--- a/apps/desktop/src/components/editor/videoPlayback/focusUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/focusUtils.ts
@@ -121,60 +121,6 @@ export function softenFocusToScale(
   };
 }
 
-/**
- * Edge snap algorithm for cursor-follow camera.
- *
- * Maps cursor position through a clamped linear remap so the camera
- * pins to the edge when the cursor is within `snapToEdgesRatio` of
- * the viewport boundary.
- *
- * With snapToEdgesRatio = 0.25 (default for manual zooms):
- *   cursor ∈ [0, 0.25]   → output 0   (camera pinned to left/top)
- *   cursor ∈ [0.25, 0.75] → linearly maps 0→1 (camera follows)
- *   cursor ∈ [0.75, 1.0]  → output 1   (camera pinned to right/bottom)
- *
- * The result is then mapped back to focus-space bounds for the given
- * zoom scale, so the camera stays within the valid viewport.
- *
- * @param snapToEdgesRatio 0.25 for manual zooms, 0.5 for system/auto zooms
- */
-export function edgeSnapFocus(
-  cursorFocus: ZoomFocus,
-  zoomScale: number,
-  snapToEdgesRatio: number,
-): ZoomFocus {
-  const bounds = getFocusBoundsForScale(zoomScale);
-
-  const snappedX = clampedInterpolate(
-    cursorFocus.cx,
-    snapToEdgesRatio,
-    1 - snapToEdgesRatio + 0.0001,
-  );
-  const snappedY = clampedInterpolate(
-    cursorFocus.cy,
-    snapToEdgesRatio,
-    1 - snapToEdgesRatio + 0.0001,
-  );
-
-  return {
-    cx: bounds.minX + snappedX * (bounds.maxX - bounds.minX),
-    cy: bounds.minY + snappedY * (bounds.maxY - bounds.minY),
-  };
-}
-
-/**
- * Clamped linear interpolation: maps `value` from [inMin, inMax] → [0, 1].
- */
-function clampedInterpolate(
-  value: number,
-  inMin: number,
-  inMax: number,
-): number {
-  if (inMax <= inMin) return 0;
-  const t = (value - inMin) / (inMax - inMin);
-  return clamp(t, 0, 1);
-}
-
 export function stageFocusToVideoSpace(
   focus: ZoomFocus,
   stageSize: StageSize,

--- a/apps/desktop/src/components/editor/videoPlayback/mathUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/mathUtils.ts
@@ -1,3 +1,5 @@
+import type { ZoomTransitionEasing } from "@/types/editor";
+
 export function clamp01(value: number) {
 	return Math.max(0, Math.min(1, value));
 }
@@ -84,3 +86,28 @@ export function easeOutCubic(t: number) {
 	const x = clamp01(t);
 	return 1 - Math.pow(1 - x, 3);
 }
+
+/**
+ * The five selectable zoom transition curves.
+ *
+ * `quiro` and `glide` are the shipped defaults and are pinned by regression
+ * tests to the curves that were previously hardcoded — `quiro` to easeOutZoom
+ * for zoom in/out, `glide` to the connected zoom-to-zoom pan. Changing either
+ * changes how every existing project moves.
+ *
+ * The other three are provisional: the control points are a starting point for
+ * the tuning sweep, not a settled taste decision.
+ */
+export const ZOOM_TRANSITION_EASINGS: Record<ZoomTransitionEasing, (t: number) => number> = {
+	// Explosive start, long soft landing. The house curve.
+	quiro: (t) => cubicBezier(0.16, 1, 0.3, 1, t),
+	// Eases away, accelerates, then coasts in. Used for connected pans.
+	glide: (t) => cubicBezier(0.1, 0.0, 0.2, 1.0, t),
+	// Symmetric ease-in-out, gentle at both ends. Matches the character of the
+	// easeInOutCubic helper; a shallower curve reads as linear.
+	smooth: (t) => cubicBezier(0.65, 0, 0.35, 1, t),
+	// Faster off the mark than quiro — over half the move in the first 5% of
+	// the time. The one that reads as a decision rather than a glide.
+	snappy: (t) => cubicBezier(0.05, 1, 0.1, 1, t),
+	linear: (t) => clamp01(t),
+};

--- a/apps/desktop/src/components/editor/videoPlayback/motionSmoothing.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/motionSmoothing.test.ts
@@ -5,6 +5,7 @@ import {
 	clampDeltaMs,
 	createSpringState,
 	getCursorSpringConfig,
+	getZoomSpringConfig,
 	resetSpringState,
 	stepSpringValue,
 } from "./motionSmoothing";
@@ -169,4 +170,63 @@ describe("getCursorSpringConfig", () => {
 		expect(stiffer.stiffness).toBeCloseTo(base.stiffness * 2, 5);
 		expect(softer.damping).toBeCloseTo(base.damping * 0.5, 5);
 	});
+});
+
+// ---------------------------------------------------------------------------
+// The overshoot guard earns its place (#28)
+//
+// Audited after the five easing curves went live. Two scenarios do NOT trigger
+// it — a smooth one-way ramp, and an abrupt square flip of the target — because
+// an overdamped spring approaches a *stationary* target monotonically. The one
+// that does is a target which reverses direction while the spring is still
+// lagging behind it: the value ends up on the far side of the target and, left
+// alone, counter-oscillates.
+//
+// These tests reproduce that geometry. They fail if the guard is removed.
+// ---------------------------------------------------------------------------
+
+describe("overshoot guard on a reversing target", () => {
+	const overdamped = [0.25, 0.5, 1]
+		.map((smoothness) =>
+			getZoomSpringConfig(smoothness, {
+				stiffnessMultiplier: 1,
+				dampingMultiplier: 1.13,
+				massMultiplier: 1.12,
+			}),
+		)
+		.filter((c) => c.damping / (2 * Math.sqrt(c.stiffness * c.mass)) >= 1);
+
+	/** Target ramps up and back down, reversing direction each half period. */
+	function triangleTarget(frame: number, periodFrames: number) {
+		const phase = (frame % periodFrames) / periodFrames;
+		const tri = phase < 0.5 ? phase * 2 : 2 - phase * 2;
+		return 1 + 3 * tri;
+	}
+
+	it("covers at least one overdamped config", () => {
+		expect(overdamped.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it.each([20, 40, 80, 160])(
+		"never leaves the value on the far side of the target (period %i frames)",
+		(periodFrames) => {
+			for (const config of overdamped) {
+				const state = createSpringState(1);
+				// Initialise at rest ON the starting target: the first call always
+				// snaps, so seeding it with the destination would test nothing.
+				stepSpringValue(state, triangleTarget(0, periodFrames), 1000 / 60, config);
+
+				for (let frame = 1; frame < 600; frame += 1) {
+					const target = triangleTarget(frame, periodFrames);
+					const before = state.value;
+					const value = stepSpringValue(state, target, 1000 / 60, config);
+
+					const crossed =
+						(before <= target && value > target) ||
+						(before >= target && value < target);
+					expect({ frame, crossed }).toEqual({ frame, crossed: false });
+				}
+			}
+		},
+	);
 });

--- a/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { ZoomRegion } from "@/types/editor";
-import { clamp01, cubicBezier, easeOutExpo, easeOutZoom } from "./mathUtils";
+import type { ZoomRegion, ZoomTransitionEasing } from "@/types/editor";
+import {
+  clamp01,
+  cubicBezier,
+  easeOutExpo,
+  easeOutZoom,
+  ZOOM_TRANSITION_EASINGS,
+} from "./mathUtils";
 import {
   clampDeltaMs,
   createSpringState,
@@ -643,13 +649,21 @@ describe("buildCameraMotionOptions", () => {
     connectZooms: true,
     zoomInDurationMs: 800,
     zoomOutDurationMs: 400,
+    zoomInEasing: "snappy",
+    zoomOutEasing: "smooth",
+    connectedZoomEasing: "linear",
   };
 
   it("carries every camera-motion setting through to the options", () => {
+    // Spelled out rather than compared to the fixture, so dropping a field
+    // from both the builder and the fixture cannot pass silently.
     expect(buildCameraMotionOptions(settings)).toEqual({
       connectZooms: true,
       zoomInDurationMs: 800,
       zoomOutDurationMs: 400,
+      zoomInEasing: "snappy",
+      zoomOutEasing: "smooth",
+      connectedZoomEasing: "linear",
     });
   });
 
@@ -659,8 +673,11 @@ describe("buildCameraMotionOptions", () => {
     const configLike = { ...settings, exportQuality: "high", width: 1920 };
     expect(Object.keys(buildCameraMotionOptions(configLike)).sort()).toEqual([
       "connectZooms",
+      "connectedZoomEasing",
       "zoomInDurationMs",
+      "zoomInEasing",
       "zoomOutDurationMs",
+      "zoomOutEasing",
     ]);
   });
 
@@ -670,5 +687,210 @@ describe("buildCameraMotionOptions", () => {
     const options = buildCameraMotionOptions({ connectZooms: false });
     expect(options.zoomInDurationMs).toBeUndefined();
     expect(options.zoomOutDurationMs).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mathUtils / zoomRegionUtils — zoom transition easing curves
+// ---------------------------------------------------------------------------
+
+describe("ZOOM_TRANSITION_EASINGS", () => {
+  const ids: ZoomTransitionEasing[] = [
+    "quiro",
+    "glide",
+    "smooth",
+    "snappy",
+    "linear",
+  ];
+
+  // REGRESSION GUARD. "quiro" is the shipped default for both zoom directions,
+  // and until now the curve was hardcoded as easeOutZoom. If these ever drift,
+  // every existing project silently changes how its zooms move.
+  it("quiro is bit-identical to the previously hardcoded zoom curve", () => {
+    for (let t = 0; t <= 1; t += 0.001) {
+      expect(ZOOM_TRANSITION_EASINGS.quiro(t)).toBe(easeOutZoom(t));
+    }
+  });
+
+  // REGRESSION GUARD. "glide" is the shipped default for connected zoom-to-zoom
+  // pans, previously hardcoded as this exact bezier inside zoomRegionUtils.
+  it("glide is bit-identical to the previously hardcoded connected-pan curve", () => {
+    for (let t = 0; t <= 1; t += 0.001) {
+      expect(ZOOM_TRANSITION_EASINGS.glide(t)).toBe(
+        cubicBezier(0.1, 0.0, 0.2, 1.0, t),
+      );
+    }
+  });
+
+  it.each(ids)("%s starts at 0 and ends at 1", (id) => {
+    expect(ZOOM_TRANSITION_EASINGS[id](0)).toBeCloseTo(0, 6);
+    expect(ZOOM_TRANSITION_EASINGS[id](1)).toBeCloseTo(1, 6);
+  });
+
+  it.each(ids)("%s is monotonic and never overshoots", (id) => {
+    let previous = -Infinity;
+    for (let t = 0; t <= 1; t += 0.005) {
+      const value = ZOOM_TRANSITION_EASINGS[id](t);
+      expect(value).toBeGreaterThanOrEqual(previous - 1e-9);
+      expect(value).toBeGreaterThanOrEqual(-1e-9);
+      expect(value).toBeLessThanOrEqual(1 + 1e-9);
+      previous = value;
+    }
+  });
+
+  it("gives each name the arrival character it advertises", () => {
+    const at = (id: ZoomTransitionEasing) => ZOOM_TRANSITION_EASINGS[id](0.5);
+
+    // Snappy arrives decisively; smooth is a gentle symmetric ease-in-out.
+    expect(at("snappy")).toBeGreaterThan(at("smooth"));
+    // Snappy must also out-run the house curve, or the name is a lie.
+    expect(at("snappy")).toBeGreaterThan(at("quiro"));
+    // Linear is the reference: exactly half way at half time.
+    expect(at("linear")).toBeCloseTo(0.5, 6);
+    // Smooth is symmetric, so it also crosses at the midpoint.
+    expect(at("smooth")).toBeCloseTo(0.5, 2);
+  });
+
+  // The point of offering five curves is that a user can tell them apart. Two
+  // curves within a hair of each other are two wasted menu entries.
+  it("keeps every pair of curves visibly distinct", () => {
+    const samples = Array.from({ length: 201 }, (_, i) => i / 200);
+    const separation = (a: ZoomTransitionEasing, b: ZoomTransitionEasing) =>
+      Math.max(
+        ...samples.map((t) =>
+          Math.abs(ZOOM_TRANSITION_EASINGS[a](t) - ZOOM_TRANSITION_EASINGS[b](t)),
+        ),
+      );
+
+    for (const a of ids) {
+      for (const b of ids) {
+        if (a >= b) continue;
+        expect({ pair: `${a}/${b}`, separation: separation(a, b) > 0.15 }).toEqual(
+          { pair: `${a}/${b}`, separation: true },
+        );
+      }
+    }
+  });
+});
+
+describe("computeRegionStrength easing", () => {
+  const region: ZoomRegion = {
+    id: "r",
+    startMs: 0,
+    endMs: 6000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+  };
+
+  it("defaults to the shipped curve when no easing is supplied", () => {
+    for (let timeMs = 0; timeMs <= 6000; timeMs += 25) {
+      expect(computeRegionStrength(region, timeMs)).toBe(
+        computeRegionStrength(region, timeMs, {
+          zoomInEasing: "quiro",
+          zoomOutEasing: "quiro",
+        }),
+      );
+    }
+  });
+
+  it("falls back instead of throwing on an unrecognised curve name", () => {
+    // Easing values arrive from persisted JSON. Before they were wired up an
+    // unknown name was inert; now it would be invoked every frame, so a stale
+    // preferences file must not be able to crash the ticker or an export.
+    const bogus = "bouncy" as ZoomTransitionEasing;
+    expect(() =>
+      computeRegionStrength(region, 700, {
+        zoomInEasing: bogus,
+        zoomOutEasing: bogus,
+      }),
+    ).not.toThrow();
+    expect(
+      computeRegionStrength(region, 700, {
+        zoomInEasing: bogus,
+        zoomOutEasing: bogus,
+      }),
+    ).toBe(computeRegionStrength(region, 700));
+  });
+
+  it("applies the zoom-in easing to the ramp up", () => {
+    const linear = computeRegionStrength(region, 700, {
+      zoomInEasing: "linear",
+    });
+    const quiro = computeRegionStrength(region, 700, { zoomInEasing: "quiro" });
+    expect(quiro).toBeGreaterThan(linear);
+  });
+
+  it("applies zoom-in and zoom-out easings independently", () => {
+    // Changing only the zoom-out easing must not move the ramp up, and vice
+    // versa. This is what makes 'punch in fast, drift out slow' possible.
+    const rampUpMs = 700;
+    expect(
+      computeRegionStrength(region, rampUpMs, {
+        zoomInEasing: "quiro",
+        zoomOutEasing: "linear",
+      }),
+    ).toBe(
+      computeRegionStrength(region, rampUpMs, {
+        zoomInEasing: "quiro",
+        zoomOutEasing: "snappy",
+      }),
+    );
+
+    const rampDownMs = 5900;
+    expect(
+      computeRegionStrength(region, rampDownMs, {
+        zoomInEasing: "linear",
+        zoomOutEasing: "quiro",
+      }),
+    ).toBe(
+      computeRegionStrength(region, rampDownMs, {
+        zoomInEasing: "snappy",
+        zoomOutEasing: "quiro",
+      }),
+    );
+  });
+});
+
+describe("connected zoom pan easing", () => {
+  const regions: ZoomRegion[] = [
+    { id: "a", startMs: 0, endMs: 2000, depth: 2, focus: { cx: 0.2, cy: 0.2 } },
+    {
+      id: "b",
+      startMs: 2600,
+      endMs: 5000,
+      depth: 5,
+      focus: { cx: 0.8, cy: 0.8 },
+    },
+  ];
+
+  // The connected pan used a second, separate hardcoded curve. Wiring only the
+  // zoom-in/out path would leave chained zooms silently ignoring the setting.
+  it("honours connectedZoomEasing during the pan between two zooms", () => {
+    const timeMs = 2400; // inside the connected transition window
+    const linear = findDominantRegion(regions, timeMs, {
+      connectZooms: true,
+      connectedZoomEasing: "linear",
+    });
+    const glide = findDominantRegion(regions, timeMs, {
+      connectZooms: true,
+      connectedZoomEasing: "glide",
+    });
+
+    expect(linear.transition).not.toBeNull();
+    expect(glide.transition).not.toBeNull();
+    expect(glide.transition?.progress).not.toBe(linear.transition?.progress);
+  });
+
+  it("defaults the connected pan to the shipped glide curve", () => {
+    for (let timeMs = 2200; timeMs <= 3200; timeMs += 20) {
+      expect(
+        findDominantRegion(regions, timeMs, { connectZooms: true }),
+      ).toEqual(
+        findDominantRegion(regions, timeMs, {
+          connectZooms: true,
+          connectedZoomEasing: "glide",
+        }),
+      );
+    }
   });
 });

--- a/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
@@ -11,7 +11,12 @@ import {
   type SpringState,
   stepSpringValue,
 } from "./motionSmoothing";
-import { computeRegionStrength, findDominantRegion } from "./zoomRegionUtils";
+import {
+  buildCameraMotionOptions,
+  type CameraMotionOptions,
+  computeRegionStrength,
+  findDominantRegion,
+} from "./zoomRegionUtils";
 
 // ---------------------------------------------------------------------------
 // motionSmoothing — spring state helpers
@@ -626,5 +631,44 @@ describe("spring damping regimes", () => {
     }
 
     expect(s.value).toBeCloseTo(1, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// zoomRegionUtils — camera-motion options builder
+// ---------------------------------------------------------------------------
+
+describe("buildCameraMotionOptions", () => {
+  const settings: CameraMotionOptions = {
+    connectZooms: true,
+    zoomInDurationMs: 800,
+    zoomOutDurationMs: 400,
+  };
+
+  it("carries every camera-motion setting through to the options", () => {
+    expect(buildCameraMotionOptions(settings)).toEqual({
+      connectZooms: true,
+      zoomInDurationMs: 800,
+      zoomOutDurationMs: 400,
+    });
+  });
+
+  it("narrows a wide render config to only the camera-motion fields", () => {
+    // Both export renderers and the native static-layout precompute pass their
+    // whole render config; nothing else may reach findDominantRegion.
+    const configLike = { ...settings, exportQuality: "high", width: 1920 };
+    expect(Object.keys(buildCameraMotionOptions(configLike)).sort()).toEqual([
+      "connectZooms",
+      "zoomInDurationMs",
+      "zoomOutDurationMs",
+    ]);
+  });
+
+  it("leaves a missing duration undefined so the region math still defaults it", () => {
+    // Defaulting here as well as in computeRegionStrength would be two sources
+    // of truth for the same value.
+    const options = buildCameraMotionOptions({ connectZooms: false });
+    expect(options.zoomInDurationMs).toBeUndefined();
+    expect(options.zoomOutDurationMs).toBeUndefined();
   });
 });

--- a/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
@@ -22,6 +22,7 @@ import {
   type CameraMotionOptions,
   computeRegionStrength,
   findDominantRegion,
+  isInstantZoomCut,
 } from "./zoomRegionUtils";
 
 // ---------------------------------------------------------------------------
@@ -892,5 +893,197 @@ describe("connected zoom pan easing", () => {
         }),
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// zoomRegionUtils — instant zoom
+// ---------------------------------------------------------------------------
+
+describe("instant zoom", () => {
+  const base: ZoomRegion = {
+    id: "r",
+    startMs: 2000,
+    endMs: 8000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+  };
+  const instant: ZoomRegion = { ...base, instant: true };
+
+  it("is off by default, leaving the ramp untouched", () => {
+    for (let timeMs = 0; timeMs <= 9000; timeMs += 25) {
+      expect(computeRegionStrength(base, timeMs)).toBe(
+        computeRegionStrength({ ...base, instant: false }, timeMs),
+      );
+    }
+  });
+
+  it("holds at zero right up to the region start", () => {
+    expect(computeRegionStrength(instant, 1999)).toBe(0);
+  });
+
+  it("lands at full strength exactly on the region start", () => {
+    expect(computeRegionStrength(instant, 2000)).toBe(1);
+  });
+
+  it("never ramps in — strength is only ever 0 or 1 before the zoom out", () => {
+    for (let timeMs = 0; timeMs <= 7000; timeMs += 5) {
+      const strength = computeRegionStrength(instant, timeMs);
+      expect(strength === 0 || strength === 1).toBe(true);
+    }
+  });
+
+  it("ramps out normally under its own duration and easing", () => {
+    // Cut in, drift out: the zoom-out must still be a real ramp, and must
+    // still honour the zoom-out easing independently.
+    const partial = computeRegionStrength(instant, 7800, {
+      zoomOutEasing: "linear",
+    });
+    expect(partial).toBeGreaterThan(0);
+    expect(partial).toBeLessThan(1);
+
+    expect(
+      computeRegionStrength(instant, 7800, { zoomOutEasing: "linear" }),
+    ).not.toBe(
+      computeRegionStrength(instant, 7800, { zoomOutEasing: "snappy" }),
+    );
+  });
+
+  it("leaves the zoom-out identical to a non-instant region", () => {
+    // Only the ramp in is bypassed; nothing about the tail changes.
+    for (let timeMs = 7600; timeMs <= 9000; timeMs += 10) {
+      expect(computeRegionStrength(instant, timeMs)).toBe(
+        computeRegionStrength(base, timeMs),
+      );
+    }
+  });
+
+  it("ignores the zoom-in easing entirely", () => {
+    for (let timeMs = 1000; timeMs <= 7000; timeMs += 25) {
+      expect(
+        computeRegionStrength(instant, timeMs, { zoomInEasing: "linear" }),
+      ).toBe(computeRegionStrength(instant, timeMs, { zoomInEasing: "quiro" }));
+    }
+  });
+
+  it("surfaces the instant region through findDominantRegion at its start", () => {
+    const result = findDominantRegion([instant], 2000);
+    expect(result.region?.id).toBe("r");
+    expect(result.strength).toBe(1);
+  });
+
+  it("still lands instantly when the region is shorter than a normal ramp", () => {
+    const brief: ZoomRegion = {
+      id: "b",
+      startMs: 1000,
+      endMs: 1400,
+      depth: 4,
+      focus: { cx: 0.5, cy: 0.5 },
+      instant: true,
+    };
+    expect(computeRegionStrength(brief, 999)).toBe(0);
+    expect(computeRegionStrength(brief, 1000)).toBe(1);
+  });
+});
+
+describe("instant zoom — regressions found in review", () => {
+  const instant: ZoomRegion = {
+    id: "i",
+    startMs: 2000,
+    endMs: 8000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+    instant: true,
+  };
+
+  // The timeline allows regions down to 100ms. The zoom-out lead is 500ms and
+  // the animation lead 200ms, so a short region used to begin ramping out
+  // before the cut had landed and never reached full depth at all.
+  it.each([100, 150, 200, 250, 299, 300, 500])(
+    "reaches full depth on a %ims region",
+    (durationMs) => {
+      const brief: ZoomRegion = {
+        ...instant,
+        startMs: 1000,
+        endMs: 1000 + durationMs,
+      };
+      expect(computeRegionStrength(brief, 999)).toBe(0);
+      expect(computeRegionStrength(brief, 1000)).toBe(1);
+    },
+  );
+
+  // connectZooms defaults on. A connected pan eases the camera into the next
+  // region and starts it early — the exact thing instant exists to avoid.
+  it("never glides into an instant region via a connected pan", () => {
+    const previous: ZoomRegion = {
+      id: "p",
+      startMs: 0,
+      endMs: 1800,
+      depth: 2,
+      focus: { cx: 0.2, cy: 0.2 },
+    };
+    const chained: ZoomRegion = { ...instant, startMs: 2000, endMs: 6000 };
+
+    // Inside what would have been the connected pan window.
+    for (let timeMs = 1800; timeMs < 2000; timeMs += 10) {
+      const result = findDominantRegion([previous, chained], timeMs, {
+        connectZooms: true,
+      });
+      expect(result.transition).toBeNull();
+      if (result.region?.id === "i") {
+        throw new Error(`instant region active ${2000 - timeMs}ms early`);
+      }
+    }
+
+    expect(
+      findDominantRegion([previous, chained], 2000, { connectZooms: true })
+        .strength,
+    ).toBe(1);
+  });
+
+  it("still chains normally when the next region is not instant", () => {
+    const previous: ZoomRegion = {
+      id: "p",
+      startMs: 0,
+      endMs: 1800,
+      depth: 2,
+      focus: { cx: 0.2, cy: 0.2 },
+    };
+    const glided: ZoomRegion = { ...instant, instant: false, startMs: 2600 };
+    // The pan window opens at endMs + the 200ms animation lead, so sample
+    // inside it rather than in the gap before it.
+    const result = findDominantRegion([previous, glided], 2500, {
+      connectZooms: true,
+    });
+    expect(result.transition).not.toBeNull();
+  });
+});
+
+describe("isInstantZoomCut", () => {
+  const instant: ZoomRegion = {
+    id: "i",
+    startMs: 0,
+    endMs: 5000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+    instant: true,
+  };
+
+  it("fires on the landing frame only", () => {
+    expect(isInstantZoomCut(instant, 1, 0)).toBe(true);
+    // Next frame: already at full strength, so the camera may move freely.
+    expect(isInstantZoomCut(instant, 1, 1)).toBe(false);
+  });
+
+  it("does not fire for a non-instant region", () => {
+    expect(isInstantZoomCut({ ...instant, instant: false }, 1, 0)).toBe(false);
+  });
+
+  it("does not fire while ramping out", () => {
+    expect(isInstantZoomCut(instant, 0.4, 1)).toBe(false);
+  });
+
+  it("does not fire when there is no region", () => {
+    expect(isInstantZoomCut(null, 1, 0)).toBe(false);
   });
 });

--- a/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
@@ -651,7 +651,10 @@ describe("buildCameraMotionOptions", () => {
   const settings: CameraMotionOptions = {
     connectZooms: true,
     zoomInDurationMs: 800,
+    zoomInOverlapMs: 700,
     zoomOutDurationMs: 400,
+    connectedZoomGapMs: 1200,
+    connectedZoomDurationMs: 900,
     zoomInEasing: "snappy",
     zoomOutEasing: "smooth",
     connectedZoomEasing: "linear",
@@ -664,7 +667,10 @@ describe("buildCameraMotionOptions", () => {
     expect(buildCameraMotionOptions(settings)).toEqual({
       connectZooms: true,
       zoomInDurationMs: 800,
+      zoomInOverlapMs: 700,
       zoomOutDurationMs: 400,
+      connectedZoomGapMs: 1200,
+      connectedZoomDurationMs: 900,
       zoomInEasing: "snappy",
       zoomOutEasing: "smooth",
       connectedZoomEasing: "linear",
@@ -678,10 +684,13 @@ describe("buildCameraMotionOptions", () => {
     const configLike = { ...settings, exportQuality: "high", width: 1920 };
     expect(Object.keys(buildCameraMotionOptions(configLike)).sort()).toEqual([
       "connectZooms",
+      "connectedZoomDurationMs",
       "connectedZoomEasing",
+      "connectedZoomGapMs",
       "zoomDrift",
       "zoomInDurationMs",
       "zoomInEasing",
+      "zoomInOverlapMs",
       "zoomOutDurationMs",
       "zoomOutEasing",
     ]);
@@ -1320,6 +1329,203 @@ describe("drift through findDominantRegion", () => {
         expect(focus.cy).toBeGreaterThanOrEqual(margin - 1e-9);
         expect(focus.cy).toBeLessThanOrEqual(1 - margin + 1e-9);
       }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// zoomRegionUtils — zoomInOverlapMs / connectedZoomGapMs / connectedZoomDurationMs (#30)
+//
+// These three were stored, persisted and threaded into every exporter config,
+// but nothing ever read them — the module-level constants ZOOM_IN_OVERLAP_MS,
+// CHAINED_ZOOM_PAN_GAP_MS and CONNECTED_ZOOM_PAN_DURATION_MS were what
+// actually ran. The shipped defaults for two of the three disagreed with
+// those constants, so wiring them up naively would have changed every
+// existing project's motion. The regression guards below are what make that
+// not true.
+// ---------------------------------------------------------------------------
+
+describe("zoomInOverlapMs", () => {
+  const region: ZoomRegion = {
+    id: "r",
+    startMs: 2000,
+    endMs: 8000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+  };
+
+  it("defaults to the value already in force (1000ms), not the stale 500ms default", () => {
+    // Identical output with the option omitted and the option explicitly set
+    // to the old in-force constant is the regression guard: an untouched
+    // project's camera must not move.
+    for (let timeMs = 0; timeMs <= 8000; timeMs += 50) {
+      expect(computeRegionStrength(region, timeMs)).toBe(
+        computeRegionStrength(region, timeMs, { zoomInOverlapMs: 1000 }),
+      );
+    }
+  });
+
+  it("a larger overlap starts the zoom-in ramp later", () => {
+    // leadInStart = region.startMs + overlap - zoomInTransitionWindow, so a
+    // bigger overlap pushes the ramp start later in time.
+    const smallOverlap = computeRegionStrength(region, 1700, {
+      zoomInOverlapMs: 200,
+    });
+    const largeOverlap = computeRegionStrength(region, 1700, {
+      zoomInOverlapMs: 1200,
+    });
+    expect(largeOverlap).toBeLessThan(smallOverlap);
+  });
+});
+
+describe("connectedZoomGapMs", () => {
+  const gapped = (gapMs: number): ZoomRegion[] => [
+    { id: "a", startMs: 0, endMs: 3000, depth: 2, focus: { cx: 0.2, cy: 0.2 } },
+    {
+      id: "b",
+      startMs: 3000 + gapMs,
+      endMs: 6000 + gapMs,
+      depth: 4,
+      focus: { cx: 0.8, cy: 0.8 },
+    },
+  ];
+
+  it("defaults to the value already in force (1350ms), not the stale 1500ms default", () => {
+    const regions = gapped(1400);
+    for (let timeMs = 3100; timeMs <= 3600; timeMs += 25) {
+      expect(
+        findDominantRegion(regions, timeMs, { connectZooms: true }),
+      ).toEqual(
+        findDominantRegion(regions, timeMs, {
+          connectZooms: true,
+          connectedZoomGapMs: 1350,
+        }),
+      );
+    }
+  });
+
+  it("a smaller gap setting stops a pair that would otherwise chain", () => {
+    const regions = gapped(1300); // chains under the 1350 default
+    const withDefault = findDominantRegion(regions, 3400, {
+      connectZooms: true,
+    });
+    expect(withDefault.transition).not.toBeNull();
+
+    const withSmallerGap = findDominantRegion(regions, 3400, {
+      connectZooms: true,
+      connectedZoomGapMs: 1000,
+    });
+    expect(withSmallerGap.transition).toBeNull();
+  });
+
+  it("a larger gap setting lets a pair chain that would not by default", () => {
+    const regions = gapped(1400); // does not chain under the 1350 default
+    const withDefault = findDominantRegion(regions, 3600, {
+      connectZooms: true,
+    });
+    expect(withDefault.transition).toBeNull();
+
+    const withLargerGap = findDominantRegion(regions, 3600, {
+      connectZooms: true,
+      connectedZoomGapMs: 1500,
+    });
+    expect(withLargerGap.transition).not.toBeNull();
+  });
+});
+
+describe("connectedZoomDurationMs", () => {
+  const regions: ZoomRegion[] = [
+    { id: "a", startMs: 0, endMs: 3000, depth: 2, focus: { cx: 0.2, cy: 0.2 } },
+    {
+      id: "b",
+      startMs: 3400,
+      endMs: 6000,
+      depth: 4,
+      focus: { cx: 0.8, cy: 0.8 },
+    },
+  ];
+
+  it("defaults to 1000ms, matching the value already in force", () => {
+    const timeMs = 3300;
+    expect(
+      findDominantRegion(regions, timeMs, { connectZooms: true }),
+    ).toEqual(
+      findDominantRegion(regions, timeMs, {
+        connectZooms: true,
+        connectedZoomDurationMs: 1000,
+      }),
+    );
+  });
+
+  it("a longer duration stretches the pan, so the same instant is earlier in it", () => {
+    const timeMs = 3600; // 200ms into the transition window either way
+    const short = findDominantRegion(regions, timeMs, {
+      connectZooms: true,
+      connectedZoomDurationMs: 500,
+    });
+    const long = findDominantRegion(regions, timeMs, {
+      connectZooms: true,
+      connectedZoomDurationMs: 4000,
+    });
+
+    expect(short.transition?.progress).not.toBeNull();
+    expect(long.transition?.progress).not.toBeNull();
+    expect(long.transition!.progress).toBeLessThan(short.transition!.progress);
+  });
+});
+
+describe("#30 regression guard — dominant-region output is unchanged under defaults", () => {
+  it("isolated region: identical across the whole ramp with and without the new options", () => {
+    const region: ZoomRegion = {
+      id: "solo",
+      startMs: 1000,
+      endMs: 6000,
+      depth: 3,
+      focus: { cx: 0.4, cy: 0.6 },
+    };
+    for (let timeMs = 0; timeMs <= 7000; timeMs += 100) {
+      expect(findDominantRegion([region], timeMs)).toEqual(
+        findDominantRegion([region], timeMs, {
+          zoomInOverlapMs: 1000,
+          connectedZoomGapMs: 1350,
+          connectedZoomDurationMs: 1000,
+        }),
+      );
+    }
+  });
+
+  it("overlapping regions: identical across the whole window", () => {
+    const regions: ZoomRegion[] = [
+      { id: "a", startMs: 0, endMs: 4000, depth: 2, focus: { cx: 0.3, cy: 0.3 } },
+      { id: "b", startMs: 3000, endMs: 7000, depth: 4, focus: { cx: 0.7, cy: 0.7 } },
+    ];
+    for (let timeMs = 0; timeMs <= 7500; timeMs += 100) {
+      expect(findDominantRegion(regions, timeMs)).toEqual(
+        findDominantRegion(regions, timeMs, {
+          zoomInOverlapMs: 1000,
+          connectedZoomGapMs: 1350,
+          connectedZoomDurationMs: 1000,
+        }),
+      );
+    }
+  });
+
+  it("chained regions: identical across the whole connected window", () => {
+    const regions: ZoomRegion[] = [
+      { id: "a", startMs: 0, endMs: 3000, depth: 2, focus: { cx: 0.2, cy: 0.2 } },
+      { id: "b", startMs: 3500, endMs: 6000, depth: 3, focus: { cx: 0.8, cy: 0.8 } },
+    ];
+    for (let timeMs = 0; timeMs <= 6500; timeMs += 50) {
+      expect(
+        findDominantRegion(regions, timeMs, { connectZooms: true }),
+      ).toEqual(
+        findDominantRegion(regions, timeMs, {
+          connectZooms: true,
+          zoomInOverlapMs: 1000,
+          connectedZoomGapMs: 1350,
+          connectedZoomDurationMs: 1000,
+        }),
+      );
     }
   });
 });

--- a/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomAnimation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ZOOM_DEPTH_SCALES } from "@/types/editor";
 import type { ZoomRegion, ZoomTransitionEasing } from "@/types/editor";
 import {
   clamp01,
@@ -21,6 +22,7 @@ import {
   buildCameraMotionOptions,
   type CameraMotionOptions,
   computeRegionStrength,
+  computeZoomDriftOffset,
   findDominantRegion,
   isInstantZoomCut,
 } from "./zoomRegionUtils";
@@ -653,6 +655,7 @@ describe("buildCameraMotionOptions", () => {
     zoomInEasing: "snappy",
     zoomOutEasing: "smooth",
     connectedZoomEasing: "linear",
+    zoomDrift: 0.4,
   };
 
   it("carries every camera-motion setting through to the options", () => {
@@ -665,6 +668,7 @@ describe("buildCameraMotionOptions", () => {
       zoomInEasing: "snappy",
       zoomOutEasing: "smooth",
       connectedZoomEasing: "linear",
+      zoomDrift: 0.4,
     });
   });
 
@@ -675,6 +679,7 @@ describe("buildCameraMotionOptions", () => {
     expect(Object.keys(buildCameraMotionOptions(configLike)).sort()).toEqual([
       "connectZooms",
       "connectedZoomEasing",
+      "zoomDrift",
       "zoomInDurationMs",
       "zoomInEasing",
       "zoomOutDurationMs",
@@ -1085,5 +1090,236 @@ describe("isInstantZoomCut", () => {
 
   it("does not fire when there is no region", () => {
     expect(isInstantZoomCut(null, 1, 0)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// zoomRegionUtils — drift while zoomed
+// ---------------------------------------------------------------------------
+
+describe("computeZoomDriftOffset", () => {
+  const held: ZoomRegion = {
+    id: "hold-1",
+    startMs: 0,
+    endMs: 10000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+    mode: "manual",
+  };
+  const mid = 5000;
+  const scale = 1.8;
+
+  it("is zero when drift is disabled, which is the default", () => {
+    expect(computeZoomDriftOffset(held, mid, scale, 0)).toEqual({
+      dx: 0,
+      dy: 0,
+    });
+    expect(computeZoomDriftOffset(held, mid, scale, undefined)).toEqual({
+      dx: 0,
+      dy: 0,
+    });
+  });
+
+  it("moves the focus when enabled", () => {
+    const offset = computeZoomDriftOffset(held, mid, scale, 1);
+    expect(Math.hypot(offset.dx, offset.dy)).toBeGreaterThan(0);
+  });
+
+  it("is zero inside a cursor-follow region", () => {
+    // Auto regions already move continuously; drift on top is noise.
+    expect(
+      computeZoomDriftOffset({ ...held, mode: "auto" }, mid, scale, 1),
+    ).toEqual({ dx: 0, dy: 0 });
+    expect(
+      computeZoomDriftOffset({ ...held, mode: undefined }, mid, scale, 1),
+    ).toEqual({ dx: 0, dy: 0 });
+  });
+
+  it("is zero for a pan-and-zoom region, which is already camera work", () => {
+    expect(
+      computeZoomDriftOffset(
+        { ...held, presetId: "pan-and-zoom" },
+        mid,
+        scale,
+        1,
+      ),
+    ).toEqual({ dx: 0, dy: 0 });
+  });
+
+  it("is zero below the minimum hold duration", () => {
+    const brief: ZoomRegion = { ...held, startMs: 0, endMs: 900 };
+    for (let timeMs = 0; timeMs <= 900; timeMs += 25) {
+      expect(computeZoomDriftOffset(brief, timeMs, scale, 1)).toEqual({
+        dx: 0,
+        dy: 0,
+      });
+    }
+  });
+
+  it("measures the hold, not the region, when deciding it is long enough", () => {
+    // A region is mostly ramp. With the default 1522ms zoom in and a 500ms
+    // zoom-out lead, a 1.6s region has no hold at all — it must not drift,
+    // even though the region itself clears the minimum.
+    const mostlyRamp: ZoomRegion = { ...held, startMs: 0, endMs: 1600 };
+    for (let timeMs = 0; timeMs <= 1600; timeMs += 25) {
+      expect(computeZoomDriftOffset(mostlyRamp, timeMs, scale, 1)).toEqual({
+        dx: 0,
+        dy: 0,
+      });
+    }
+  });
+
+  it("never drifts while the zoom in is still running", () => {
+    // Drift exists for the static hold. Running during the ramp would fight
+    // the very motion it is waiting for.
+    for (let timeMs = 0; timeMs < 1522; timeMs += 10) {
+      expect(computeZoomDriftOffset(held, timeMs, scale, 1)).toEqual({
+        dx: 0,
+        dy: 0,
+      });
+    }
+  });
+
+  it("starts drifting once the hold has begun", () => {
+    const justInside = computeZoomDriftOffset(held, 2600, scale, 1);
+    expect(Math.hypot(justInside.dx, justInside.dy)).toBeGreaterThan(0);
+  });
+
+  it("follows a custom zoom-in duration rather than assuming the default", () => {
+    // A short zoom in means the hold starts sooner.
+    expect(computeZoomDriftOffset(held, 900, scale, 1, 300)).not.toEqual({
+      dx: 0,
+      dy: 0,
+    });
+    expect(computeZoomDriftOffset(held, 900, scale, 1, 4000)).toEqual({
+      dx: 0,
+      dy: 0,
+    });
+  });
+
+  it("starts the hold at the cut for an instant zoom", () => {
+    const cut: ZoomRegion = { ...held, instant: true };
+    expect(computeZoomDriftOffset(cut, 700, scale, 1)).not.toEqual({
+      dx: 0,
+      dy: 0,
+    });
+  });
+
+  it("is zero outside the region", () => {
+    expect(computeZoomDriftOffset(held, -1, scale, 1)).toEqual({
+      dx: 0,
+      dy: 0,
+    });
+    expect(computeZoomDriftOffset(held, 10001, scale, 1)).toEqual({
+      dx: 0,
+      dy: 0,
+    });
+  });
+
+  it("ramps from nothing at both ends of the hold", () => {
+    // Hold runs from startMs + zoomInDurationMs to endMs - the zoom-out lead.
+    // The default zoom-in duration is 1015.05 * 1.5, which is not exactly
+    // representable, so assert the claim — amplitude starts at nothing —
+    // rather than a hardcoded boundary value.
+    const holdStart = 1015.05 * 1.5;
+    const holdEnd = 10000 - 500;
+    const atStart = computeZoomDriftOffset(held, holdStart, scale, 1);
+    expect(Math.hypot(atStart.dx, atStart.dy)).toBeLessThan(1e-9);
+    expect(computeZoomDriftOffset(held, holdEnd, scale, 1)).toEqual({
+      dx: 0,
+      dy: 0,
+    });
+
+    // And grows in, rather than snapping on.
+    const early = computeZoomDriftOffset(held, holdStart + 60, scale, 1);
+    const later = computeZoomDriftOffset(held, holdStart + 400, scale, 1);
+    expect(Math.hypot(early.dx, early.dy)).toBeLessThan(
+      Math.hypot(later.dx, later.dy),
+    );
+  });
+
+  it("is deterministic — same inputs, same output, forever", () => {
+    // Re-exporting a project must produce identical frames.
+    for (let timeMs = 0; timeMs <= 10000; timeMs += 137) {
+      expect(computeZoomDriftOffset(held, timeMs, scale, 0.7)).toEqual(
+        computeZoomDriftOffset(held, timeMs, scale, 0.7),
+      );
+    }
+  });
+
+  it("gives different regions different phase, so they do not move in lockstep", () => {
+    const a = computeZoomDriftOffset(held, mid, scale, 1);
+    const b = computeZoomDriftOffset({ ...held, id: "hold-2" }, mid, scale, 1);
+    expect(a).not.toEqual(b);
+  });
+
+  it("scales with the strength setting", () => {
+    const weak = computeZoomDriftOffset(held, mid, scale, 0.25);
+    const strong = computeZoomDriftOffset(held, mid, scale, 1);
+    expect(Math.hypot(strong.dx, strong.dy)).toBeGreaterThan(
+      Math.hypot(weak.dx, weak.dy),
+    );
+  });
+
+  it("shrinks as the zoom goes deeper, so on-screen travel stays comparable", () => {
+    const shallow = computeZoomDriftOffset(held, mid, 1.25, 1);
+    const deep = computeZoomDriftOffset(held, mid, 5, 1);
+    expect(Math.hypot(deep.dx, deep.dy)).toBeLessThan(
+      Math.hypot(shallow.dx, shallow.dy),
+    );
+  });
+
+  it("stays small enough to read as drift rather than a pan", () => {
+    let peak = 0;
+    for (let timeMs = 0; timeMs <= 10000; timeMs += 10) {
+      const o = computeZoomDriftOffset(held, timeMs, 1, 1);
+      peak = Math.max(peak, Math.hypot(o.dx, o.dy));
+    }
+    expect(peak).toBeGreaterThan(0.01);
+    expect(peak).toBeLessThan(0.08);
+  });
+});
+
+describe("drift through findDominantRegion", () => {
+  const held: ZoomRegion = {
+    id: "hold-1",
+    startMs: 0,
+    endMs: 10000,
+    depth: 3,
+    focus: { cx: 0.5, cy: 0.5 },
+    mode: "manual",
+  };
+
+  it("leaves focus untouched when drift is off", () => {
+    const result = findDominantRegion([held], 5000);
+    expect(result.region?.focus).toEqual({ cx: 0.5, cy: 0.5 });
+  });
+
+  it("moves focus when drift is on", () => {
+    const result = findDominantRegion([held], 5000, { zoomDrift: 1 });
+    expect(result.region?.focus).not.toEqual({ cx: 0.5, cy: 0.5 });
+  });
+
+  it("never drifts the frame past the video edge at any depth", () => {
+    // Drift rides on the existing focus clamp, so an edge-pinned focus at max
+    // strength must stay inside bounds.
+    for (const depth of [1, 2, 3, 4, 5, 6] as const) {
+      const edge: ZoomRegion = {
+        ...held,
+        depth,
+        focus: { cx: 1, cy: 0 },
+      };
+      for (let timeMs = 0; timeMs <= 10000; timeMs += 50) {
+        const focus = findDominantRegion([edge], timeMs, {
+          zoomDrift: 1,
+        }).region?.focus;
+        if (!focus) continue;
+        const margin = 1 / (2 * ZOOM_DEPTH_SCALES[depth]);
+        expect(focus.cx).toBeGreaterThanOrEqual(margin - 1e-9);
+        expect(focus.cx).toBeLessThanOrEqual(1 - margin + 1e-9);
+        expect(focus.cy).toBeGreaterThanOrEqual(margin - 1e-9);
+        expect(focus.cy).toBeLessThanOrEqual(1 - margin + 1e-9);
+      }
+    }
   });
 });

--- a/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
@@ -13,11 +13,33 @@ const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
 const ZOOM_IN_OVERLAP_MS = 1000;
 const ZOOM_ANIMATION_LEAD_MS = 200;
 
-type DominantRegionOptions = {
+export type CameraMotionOptions = {
   connectZooms?: boolean;
   zoomInDurationMs?: number;
   zoomOutDurationMs?: number;
 };
+
+/**
+ * The single place camera-motion options are assembled.
+ *
+ * Callers pass an object they already own and it is narrowed to just the
+ * camera-motion fields — the export renderers hand over their whole render
+ * config, the preview a memoised object built from its props. Adding a camera
+ * parameter is a change here, not a hunt across four call sites.
+ *
+ * Deliberately applies no defaults. `computeRegionStrength` already falls back
+ * for a missing duration; defaulting here as well would put the same value in
+ * two places and let them drift.
+ */
+export function buildCameraMotionOptions(
+  settings: CameraMotionOptions,
+): CameraMotionOptions {
+  return {
+    connectZooms: settings.connectZooms,
+    zoomInDurationMs: settings.zoomInDurationMs,
+    zoomOutDurationMs: settings.zoomOutDurationMs,
+  };
+}
 
 type ConnectedRegionPair = {
   currentRegion: ZoomRegion;
@@ -46,7 +68,7 @@ export function computeRegionStrength(
   region: ZoomRegion,
   timeMs: number,
   options: Pick<
-    DominantRegionOptions,
+    CameraMotionOptions,
     "zoomInDurationMs" | "zoomOutDurationMs"
   > = {},
 ) {
@@ -153,7 +175,7 @@ function getActiveRegion(
   regions: ZoomRegion[],
   timeMs: number,
   connectedPairs: ConnectedRegionPair[],
-  options: DominantRegionOptions,
+  options: CameraMotionOptions,
 ) {
   const activeRegions = regions
     .map((region) => {
@@ -284,7 +306,7 @@ function getConnectedRegionTransition(
 export function findDominantRegion(
   regions: ZoomRegion[],
   timeMs: number,
-  options: DominantRegionOptions = {},
+  options: CameraMotionOptions = {},
 ): {
   region: ZoomRegion | null;
   strength: number;

--- a/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
@@ -4,8 +4,11 @@ import type {
   ZoomTransitionEasing,
 } from "@/types/editor";
 import {
+  DEFAULT_CONNECTED_ZOOM_DURATION_MS,
   DEFAULT_CONNECTED_ZOOM_EASING,
+  DEFAULT_CONNECTED_ZOOM_GAP_MS,
   DEFAULT_ZOOM_IN_EASING,
+  DEFAULT_ZOOM_IN_OVERLAP_MS,
   DEFAULT_ZOOM_OUT_EASING,
   ZOOM_DEPTH_SCALES,
 } from "@/types/editor";
@@ -32,15 +35,15 @@ const DRIFT_VERTICAL_PHASE_OFFSET = 1.37;
 const TAU = Math.PI * 2;
 const NO_DRIFT = Object.freeze({ dx: 0, dy: 0 });
 
-const CHAINED_ZOOM_PAN_GAP_MS = 1350;
-const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
-const ZOOM_IN_OVERLAP_MS = 1000;
 const ZOOM_ANIMATION_LEAD_MS = 200;
 
 export type CameraMotionOptions = {
   connectZooms?: boolean;
   zoomInDurationMs?: number;
+  zoomInOverlapMs?: number;
   zoomOutDurationMs?: number;
+  connectedZoomGapMs?: number;
+  connectedZoomDurationMs?: number;
   zoomInEasing?: ZoomTransitionEasing;
   zoomOutEasing?: ZoomTransitionEasing;
   connectedZoomEasing?: ZoomTransitionEasing;
@@ -83,7 +86,10 @@ export function buildCameraMotionOptions(
   return {
     connectZooms: settings.connectZooms,
     zoomInDurationMs: settings.zoomInDurationMs,
+    zoomInOverlapMs: settings.zoomInOverlapMs,
     zoomOutDurationMs: settings.zoomOutDurationMs,
+    connectedZoomGapMs: settings.connectedZoomGapMs,
+    connectedZoomDurationMs: settings.connectedZoomDurationMs,
     zoomInEasing: settings.zoomInEasing,
     zoomOutEasing: settings.zoomOutEasing,
     connectedZoomEasing: settings.connectedZoomEasing,
@@ -223,6 +229,7 @@ export function computeRegionStrength(
   options: Pick<
     CameraMotionOptions,
     | "zoomInDurationMs"
+    | "zoomInOverlapMs"
     | "zoomOutDurationMs"
     | "zoomInEasing"
     | "zoomOutEasing"
@@ -232,13 +239,14 @@ export function computeRegionStrength(
     1,
     options.zoomInDurationMs ?? ZOOM_IN_TRANSITION_WINDOW_MS,
   );
+  const zoomInOverlapMs = options.zoomInOverlapMs ?? DEFAULT_ZOOM_IN_OVERLAP_MS;
   const zoomOutDurationMs = Math.max(
     1,
     options.zoomOutDurationMs ?? TRANSITION_WINDOW_MS,
   );
   const adjustedTimeMs = timeMs - ZOOM_ANIMATION_LEAD_MS;
   const leadInStart =
-    region.startMs + ZOOM_IN_OVERLAP_MS - ZOOM_IN_TRANSITION_WINDOW_MS;
+    region.startMs + zoomInOverlapMs - ZOOM_IN_TRANSITION_WINDOW_MS;
   let zoomOutStart = region.endMs - ZOOM_OUT_EARLY_START_MS;
   let zoomInEnd = leadInStart + zoomInDurationMs;
 
@@ -345,7 +353,17 @@ function getResolvedFocus(
   return clampFocusToScale(region.focus, zoomScale);
 }
 
-function getConnectedRegionPairs(regions: ZoomRegion[]) {
+function getConnectedRegionPairs(
+  regions: ZoomRegion[],
+  options: Pick<
+    CameraMotionOptions,
+    "connectedZoomGapMs" | "connectedZoomDurationMs"
+  >,
+) {
+  const connectedZoomGapMs =
+    options.connectedZoomGapMs ?? DEFAULT_CONNECTED_ZOOM_GAP_MS;
+  const connectedZoomDurationMs =
+    options.connectedZoomDurationMs ?? DEFAULT_CONNECTED_ZOOM_DURATION_MS;
   const sortedRegions = [...regions].sort((a, b) => a.startMs - b.startMs);
   const pairs: ConnectedRegionPair[] = [];
 
@@ -354,7 +372,7 @@ function getConnectedRegionPairs(regions: ZoomRegion[]) {
     const nextRegion = sortedRegions[index + 1];
     const gapMs = nextRegion.startMs - currentRegion.endMs;
 
-    if (gapMs > CHAINED_ZOOM_PAN_GAP_MS) {
+    if (gapMs > connectedZoomGapMs) {
       continue;
     }
 
@@ -370,9 +388,7 @@ function getConnectedRegionPairs(regions: ZoomRegion[]) {
       nextRegion,
       transitionStart: currentRegion.endMs + ZOOM_ANIMATION_LEAD_MS,
       transitionEnd:
-        currentRegion.endMs +
-        ZOOM_ANIMATION_LEAD_MS +
-        CONNECTED_ZOOM_PAN_DURATION_MS,
+        currentRegion.endMs + ZOOM_ANIMATION_LEAD_MS + connectedZoomDurationMs,
     });
   }
 
@@ -535,7 +551,7 @@ export function findDominantRegion(
   transition: ConnectedPanTransition | null;
 } {
   const connectedPairs = options.connectZooms
-    ? getConnectedRegionPairs(regions)
+    ? getConnectedRegionPairs(regions, options)
     : [];
 
   if (options.connectZooms) {

--- a/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
@@ -93,6 +93,25 @@ function lerp(start: number, end: number, amount: number) {
   return start + (end - start) * amount;
 }
 
+/**
+ * True only on the frame an instant zoom lands.
+ *
+ * Edge-triggered on purpose. Two things key off it, and both are wrong if it
+ * stays true for the whole region: the camera spring has to be snapped past
+ * (otherwise the spring glides the cut and "instant" is not instant), and
+ * motion blur has to be dropped (otherwise the largest camera delta in the
+ * project smears the frame meant to read as a cut). During the rest of the
+ * hold the camera can legitimately move — cursor-follow and pan-and-zoom both
+ * do — and that motion should spring and blur normally.
+ */
+export function isInstantZoomCut(
+  region: ZoomRegion | null,
+  strength: number,
+  previousProgress: number,
+) {
+  return region?.instant === true && strength >= 1 && previousProgress < 1;
+}
+
 export function computeRegionStrength(
   region: ZoomRegion,
   timeMs: number,
@@ -117,6 +136,29 @@ export function computeRegionStrength(
     region.startMs + ZOOM_IN_OVERLAP_MS - ZOOM_IN_TRANSITION_WINDOW_MS;
   let zoomOutStart = region.endMs - ZOOM_OUT_EARLY_START_MS;
   let zoomInEnd = leadInStart + zoomInDurationMs;
+
+  // Instant zoom: no ramp in, so no anticipation lead either — the cut has to
+  // land on the frame the region starts, not 200ms before it. The zoom out is
+  // deliberately left alone so cut-in / drift-out is the default shape.
+  if (region.instant) {
+    if (timeMs < region.startMs) {
+      return 0;
+    }
+    // A region shorter than the zoom-out lead would otherwise start its ramp
+    // out before the cut had landed, so the cut would never reach full depth.
+    // The hold always begins where the cut lands.
+    const instantZoomOutStart = Math.max(zoomOutStart, region.startMs);
+    if (adjustedTimeMs <= instantZoomOutStart) {
+      return 1;
+    }
+    const outProgress = clamp01(
+      (adjustedTimeMs - instantZoomOutStart) / zoomOutDurationMs,
+    );
+    return (
+      1 -
+      resolveEasing(options.zoomOutEasing, DEFAULT_ZOOM_OUT_EASING)(outProgress)
+    );
+  }
 
   if (zoomInEnd > zoomOutStart) {
     const midpoint = (zoomInEnd + zoomOutStart) / 2;
@@ -188,6 +230,13 @@ function getConnectedRegionPairs(regions: ZoomRegion[]) {
     const gapMs = nextRegion.startMs - currentRegion.endMs;
 
     if (gapMs > CHAINED_ZOOM_PAN_GAP_MS) {
+      continue;
+    }
+
+    // You cannot glide into a cut. A connected pan would ease the camera into
+    // the next region and start it early, which is exactly what instant
+    // exists to avoid — so an instant region never chains from its neighbour.
+    if (nextRegion.instant) {
       continue;
     }
 

--- a/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
@@ -17,6 +17,21 @@ import {
 import { clampFocusToScale } from "./focusUtils";
 import { clamp01, ZOOM_TRANSITION_EASINGS } from "./mathUtils";
 
+// Drift tuning. Provisional — the character of the motion is a taste decision
+// the tuning sweep is expected to revisit. What is *not* provisional: it must
+// stay deterministic, bounded, and off by default.
+const DRIFT_MIN_HOLD_MS = 1500;
+const DRIFT_RAMP_MS = 600;
+const DRIFT_PERIOD_X_MS = 11000;
+const DRIFT_PERIOD_Y_MS = 7000;
+const DRIFT_MAX_OFFSET = 0.045;
+const DRIFT_VERTICAL_WEIGHT = 0.6;
+// Offsets the vertical phase from the horizontal one so the pair traces a slow
+// open path rather than a diagonal line.
+const DRIFT_VERTICAL_PHASE_OFFSET = 1.37;
+const TAU = Math.PI * 2;
+const NO_DRIFT = Object.freeze({ dx: 0, dy: 0 });
+
 const CHAINED_ZOOM_PAN_GAP_MS = 1350;
 const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
 const ZOOM_IN_OVERLAP_MS = 1000;
@@ -29,6 +44,7 @@ export type CameraMotionOptions = {
   zoomInEasing?: ZoomTransitionEasing;
   zoomOutEasing?: ZoomTransitionEasing;
   connectedZoomEasing?: ZoomTransitionEasing;
+  zoomDrift?: number;
 };
 
 /**
@@ -71,6 +87,7 @@ export function buildCameraMotionOptions(
     zoomInEasing: settings.zoomInEasing,
     zoomOutEasing: settings.zoomOutEasing,
     connectedZoomEasing: settings.connectedZoomEasing,
+    zoomDrift: settings.zoomDrift,
   };
 }
 
@@ -91,6 +108,94 @@ type ConnectedPanTransition = {
 
 function lerp(start: number, end: number, amount: number) {
   return start + (end - start) * amount;
+}
+
+/** FNV-1a, folded to 0..1. Gives each region a stable phase from its id. */
+function hashToUnitInterval(id: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < id.length; index += 1) {
+    hash ^= id.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return ((hash >>> 0) % 100000) / 100000;
+}
+
+/**
+ * Slow parallax while a zoom is held, so a long hold reads as a camera pointed
+ * at something rather than a cropped screenshot.
+ *
+ * Two slow sinusoids at incommensurate periods, phase-seeded from the region
+ * id so neighbouring zooms do not move in lockstep. Deterministic by
+ * construction — a pure function of the region, the time within it and the
+ * settings, with no RNG, no accumulated state and no wall-clock — because
+ * re-exporting a project has to produce identical frames.
+ *
+ * Returns an offset in focus space. The caller re-clamps, so drift inherits
+ * the existing bounds and can never reveal an edge.
+ */
+export function computeZoomDriftOffset(
+  region: ZoomRegion,
+  timeMs: number,
+  zoomScale: number,
+  driftStrength: number | undefined,
+  zoomInDurationMs: number = ZOOM_IN_TRANSITION_WINDOW_MS,
+) {
+  // Ordered cheapest-first: the common case is drift off, and this runs every
+  // frame for every region.
+  if (!driftStrength || driftStrength <= 0) {
+    return NO_DRIFT;
+  }
+  // Auto regions are already tracking the cursor; drift on top is just noise.
+  // pan-and-zoom is likewise already deliberate camera work.
+  if (region.mode !== "manual" || region.presetId === "pan-and-zoom") {
+    return NO_DRIFT;
+  }
+
+  // Measured over the *hold*, not the region. A region is mostly ramp: with
+  // the default 1522ms zoom in, a 1.6s region has no hold at all. Gating and
+  // ramping on region bounds would let drift run at full amplitude while the
+  // zoom was still moving, which is the motion it is supposed to wait for.
+  const holdStartMs = region.instant
+    ? region.startMs
+    : region.startMs + zoomInDurationMs;
+  const holdEndMs = region.endMs - ZOOM_OUT_EARLY_START_MS;
+  const holdMs = holdEndMs - holdStartMs;
+  if (holdMs < DRIFT_MIN_HOLD_MS) {
+    return NO_DRIFT;
+  }
+
+  const elapsedMs = timeMs - holdStartMs;
+  if (elapsedMs < 0 || elapsedMs > holdMs) {
+    return NO_DRIFT;
+  }
+
+  // Zero at both ends so drift neither snaps on nor fights the zoom out.
+  const ramp = Math.min(
+    1,
+    elapsedMs / DRIFT_RAMP_MS,
+    (holdMs - elapsedMs) / DRIFT_RAMP_MS,
+  );
+  if (ramp <= 0) {
+    return NO_DRIFT;
+  }
+
+  const phase = hashToUnitInterval(region.id);
+  // Divided by the zoom scale so on-screen travel stays comparable as the
+  // zoom goes deeper — the same focus-space offset covers more pixels at 5x.
+  const amplitude =
+    (DRIFT_MAX_OFFSET * clamp01(driftStrength) * ramp) / Math.max(1, zoomScale);
+
+  return {
+    dx: Math.sin(TAU * (elapsedMs / DRIFT_PERIOD_X_MS + phase)) * amplitude,
+    dy:
+      Math.sin(
+        TAU *
+          (elapsedMs / DRIFT_PERIOD_Y_MS +
+            phase * DRIFT_VERTICAL_PHASE_OFFSET),
+      ) *
+      amplitude *
+      DRIFT_VERTICAL_WEIGHT,
+  };
 }
 
 /**
@@ -202,6 +307,8 @@ function getResolvedFocus(
   region: ZoomRegion,
   zoomScale: number,
   timeMs?: number,
+  driftStrength?: number,
+  zoomInDurationMs?: number,
 ): ZoomFocus {
   if (
     region.presetId === "pan-and-zoom" &&
@@ -217,6 +324,24 @@ function getResolvedFocus(
       zoomScale,
     );
   }
+
+  if (driftStrength && Number.isFinite(timeMs)) {
+    const drift = computeZoomDriftOffset(
+      region,
+      timeMs as number,
+      zoomScale,
+      driftStrength,
+      zoomInDurationMs,
+    );
+    if (drift.dx !== 0 || drift.dy !== 0) {
+      // Clamped here, so drift can never push the frame past a video edge.
+      return clampFocusToScale(
+        { cx: region.focus.cx + drift.dx, cy: region.focus.cy + drift.dy },
+        zoomScale,
+      );
+    }
+  }
+
   return clampFocusToScale(region.focus, zoomScale);
 }
 
@@ -310,7 +435,16 @@ function getActiveRegion(
   return {
     region: {
       ...activeRegion,
-      focus: getResolvedFocus(activeRegion, activeScale, timeMs),
+      // Connected holds and pans deliberately do not drift: the camera there
+      // is either chained or already in motion, which is not the static-frame
+      // problem drift exists to solve.
+      focus: getResolvedFocus(
+        activeRegion,
+        activeScale,
+        timeMs,
+        options.zoomDrift,
+        options.zoomInDurationMs,
+      ),
     },
     strength: activeRegions[0].strength,
     blendedScale: null,

--- a/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomRegionUtils.ts
@@ -1,12 +1,21 @@
-import type { ZoomFocus, ZoomRegion } from "@/types/editor";
-import { ZOOM_DEPTH_SCALES } from "@/types/editor";
+import type {
+  ZoomFocus,
+  ZoomRegion,
+  ZoomTransitionEasing,
+} from "@/types/editor";
+import {
+  DEFAULT_CONNECTED_ZOOM_EASING,
+  DEFAULT_ZOOM_IN_EASING,
+  DEFAULT_ZOOM_OUT_EASING,
+  ZOOM_DEPTH_SCALES,
+} from "@/types/editor";
 import {
   TRANSITION_WINDOW_MS,
   ZOOM_IN_TRANSITION_WINDOW_MS,
   ZOOM_OUT_EARLY_START_MS,
 } from "./constants";
 import { clampFocusToScale } from "./focusUtils";
-import { clamp01, cubicBezier, easeOutZoom } from "./mathUtils";
+import { clamp01, ZOOM_TRANSITION_EASINGS } from "./mathUtils";
 
 const CHAINED_ZOOM_PAN_GAP_MS = 1350;
 const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
@@ -17,7 +26,28 @@ export type CameraMotionOptions = {
   connectZooms?: boolean;
   zoomInDurationMs?: number;
   zoomOutDurationMs?: number;
+  zoomInEasing?: ZoomTransitionEasing;
+  zoomOutEasing?: ZoomTransitionEasing;
+  connectedZoomEasing?: ZoomTransitionEasing;
 };
+
+/**
+ * Falls back on an unrecognised curve name rather than trusting the type.
+ *
+ * Easing values reach here from persisted JSON, and until these curves were
+ * wired up an unknown value was inert. Now it would be called every frame, so
+ * a stale or hand-edited preferences file must not be able to throw inside the
+ * ticker.
+ */
+function resolveEasing(
+  easing: ZoomTransitionEasing | undefined,
+  fallback: ZoomTransitionEasing,
+) {
+  return (
+    (easing && ZOOM_TRANSITION_EASINGS[easing]) ??
+    ZOOM_TRANSITION_EASINGS[fallback]
+  );
+}
 
 /**
  * The single place camera-motion options are assembled.
@@ -38,6 +68,9 @@ export function buildCameraMotionOptions(
     connectZooms: settings.connectZooms,
     zoomInDurationMs: settings.zoomInDurationMs,
     zoomOutDurationMs: settings.zoomOutDurationMs,
+    zoomInEasing: settings.zoomInEasing,
+    zoomOutEasing: settings.zoomOutEasing,
+    connectedZoomEasing: settings.connectedZoomEasing,
   };
 }
 
@@ -60,16 +93,15 @@ function lerp(start: number, end: number, amount: number) {
   return start + (end - start) * amount;
 }
 
-function easeConnectedPan(value: number) {
-  return cubicBezier(0.1, 0.0, 0.2, 1.0, value);
-}
-
 export function computeRegionStrength(
   region: ZoomRegion,
   timeMs: number,
   options: Pick<
     CameraMotionOptions,
-    "zoomInDurationMs" | "zoomOutDurationMs"
+    | "zoomInDurationMs"
+    | "zoomOutDurationMs"
+    | "zoomInEasing"
+    | "zoomOutEasing"
   > = {},
 ) {
   const zoomInDurationMs = Math.max(
@@ -100,7 +132,7 @@ export function computeRegionStrength(
 
   if (adjustedTimeMs < zoomInEnd) {
     const progress = (adjustedTimeMs - leadInStart) / zoomInDurationMs;
-    return easeOutZoom(progress);
+    return resolveEasing(options.zoomInEasing, DEFAULT_ZOOM_IN_EASING)(progress);
   }
 
   if (adjustedTimeMs <= zoomOutStart) {
@@ -108,7 +140,9 @@ export function computeRegionStrength(
   }
 
   const progress = clamp01((adjustedTimeMs - zoomOutStart) / zoomOutDurationMs);
-  return 1 - easeOutZoom(progress);
+  return (
+    1 - resolveEasing(options.zoomOutEasing, DEFAULT_ZOOM_OUT_EASING)(progress)
+  );
 }
 
 function getLinearFocus(
@@ -258,6 +292,7 @@ function getConnectedRegionHold(
 function getConnectedRegionTransition(
   connectedPairs: ConnectedRegionPair[],
   timeMs: number,
+  options: Pick<CameraMotionOptions, "connectedZoomEasing">,
 ) {
   for (const pair of connectedPairs) {
     const { currentRegion, nextRegion, transitionStart, transitionEnd } = pair;
@@ -266,7 +301,10 @@ function getConnectedRegionTransition(
       continue;
     }
 
-    const transitionProgress = easeConnectedPan(
+    const transitionProgress = resolveEasing(
+      options.connectedZoomEasing,
+      DEFAULT_CONNECTED_ZOOM_EASING,
+    )(
       clamp01(
         (timeMs - transitionStart) /
           Math.max(1, transitionEnd - transitionStart),
@@ -321,6 +359,7 @@ export function findDominantRegion(
     const connectedTransition = getConnectedRegionTransition(
       connectedPairs,
       timeMs,
+      options,
     );
     if (connectedTransition) {
       return connectedTransition;

--- a/apps/desktop/src/components/editor/videoPlayback/zoomTransform.ts
+++ b/apps/desktop/src/components/editor/videoPlayback/zoomTransform.ts
@@ -40,6 +40,16 @@ interface TransformParams {
   focusY: number;
   isPlaying: boolean;
   motionBlurAmount?: number;
+  /**
+   * Skip the blur pass and re-baseline the velocity state for this frame.
+   *
+   * An instant zoom produces the largest camera delta in the project in a
+   * single frame. Blur derived from that delta smears exactly the frame that
+   * is supposed to read as a hard cut, so callers suppress it while an instant
+   * region is held. Resetting rather than merely zeroing also protects the
+   * following frame, which would otherwise measure the jump as velocity.
+   */
+  suppressMotionBlur?: boolean;
   motionBlurTuning?: ZoomMotionBlurTuning;
   transformOverride?: AppliedTransform;
   motionBlurState?: MotionBlurState;
@@ -499,6 +509,7 @@ export function applyZoomTransform({
   focusY,
   isPlaying,
   motionBlurAmount = 0,
+  suppressMotionBlur = false,
   motionBlurTuning,
   transformOverride,
   motionBlurState,
@@ -535,6 +546,7 @@ export function applyZoomTransform({
   if (
     motionBlurState &&
     motionBlurFilter &&
+    !suppressMotionBlur &&
     motionBlurAmount > 0 &&
     isPlaying
   ) {

--- a/apps/desktop/src/components/editor/window.tsx
+++ b/apps/desktop/src/components/editor/window.tsx
@@ -358,6 +358,9 @@ export default function EditorWindow() {
   const [backgroundBlur, setBackgroundBlur] = useState(
     initialEditorPreferences.backgroundBlur,
   );
+  const [zoomDrift, setZoomDrift] = useState(
+    initialEditorPreferences.zoomDrift,
+  );
   const [zoomMotionBlur, setZoomMotionBlur] = useState(
     initialEditorPreferences.zoomMotionBlur,
   );
@@ -966,6 +969,7 @@ export default function EditorWindow() {
       shadowIntensity,
       backgroundBlur,
       zoomMotionBlur,
+      zoomDrift,
       zoomMotionBlurTuning: { ...zoomMotionBlurTuning },
       zoomTemporalMotionBlur,
       zoomMotionBlurSampleCount,
@@ -1018,6 +1022,7 @@ export default function EditorWindow() {
       shadowIntensity,
       backgroundBlur,
       zoomMotionBlur,
+      zoomDrift,
       zoomMotionBlurTuning,
       zoomTemporalMotionBlur,
       zoomMotionBlurSampleCount,
@@ -1121,6 +1126,7 @@ export default function EditorWindow() {
       setShadowIntensity(snapshot.shadowIntensity);
       setBackgroundBlur(snapshot.backgroundBlur);
       setZoomMotionBlur(snapshot.zoomMotionBlur);
+      setZoomDrift(snapshot.zoomDrift);
       setZoomMotionBlurTuning({ ...snapshot.zoomMotionBlurTuning });
       setZoomTemporalMotionBlur(snapshot.zoomTemporalMotionBlur);
       setZoomMotionBlurSampleCount(snapshot.zoomMotionBlurSampleCount);
@@ -1377,6 +1383,7 @@ export default function EditorWindow() {
           shadowIntensity,
           backgroundBlur,
           zoomMotionBlur,
+          zoomDrift,
           zoomMotionBlurTuning,
           zoomTemporalMotionBlur,
           zoomMotionBlurSampleCount,
@@ -1544,6 +1551,7 @@ export default function EditorWindow() {
     zoomInEasing,
     zoomInOverlapMs,
     zoomMotionBlur,
+    zoomDrift,
     zoomMotionBlurTuning,
     zoomTemporalMotionBlur,
     zoomMotionBlurSampleCount,
@@ -1816,6 +1824,7 @@ export default function EditorWindow() {
         shadowIntensity: number;
         backgroundBlur: number;
         zoomMotionBlur: number;
+        zoomDrift: number;
         zoomMotionBlurTuning: ZoomMotionBlurTuning;
         zoomTemporalMotionBlur: number;
         zoomMotionBlurSampleCount: number | null;
@@ -1968,6 +1977,7 @@ export default function EditorWindow() {
         shadowIntensity,
         backgroundBlur,
         zoomMotionBlur,
+        zoomDrift,
         zoomMotionBlurTuning,
         zoomTemporalMotionBlur,
         zoomMotionBlurSampleCount,
@@ -2030,6 +2040,7 @@ export default function EditorWindow() {
       shadowIntensity,
       backgroundBlur,
       zoomMotionBlur,
+      zoomDrift,
       zoomMotionBlurTuning,
       zoomTemporalMotionBlur,
       zoomMotionBlurSampleCount,
@@ -2257,6 +2268,7 @@ export default function EditorWindow() {
       setShadowIntensity(normalizedEditor.shadowIntensity);
       setBackgroundBlur(normalizedEditor.backgroundBlur);
       setZoomMotionBlur(normalizedEditor.zoomMotionBlur);
+      setZoomDrift(normalizedEditor.zoomDrift);
       setZoomMotionBlurTuning({ ...normalizedEditor.zoomMotionBlurTuning });
       setZoomTemporalMotionBlur(normalizedEditor.zoomTemporalMotionBlur);
       setZoomMotionBlurSampleCount(normalizedEditor.zoomMotionBlurSampleCount);
@@ -2442,6 +2454,7 @@ export default function EditorWindow() {
       setShadowIntensity(normalizedEditor.shadowIntensity);
       setBackgroundBlur(normalizedEditor.backgroundBlur);
       setZoomMotionBlur(normalizedEditor.zoomMotionBlur);
+      setZoomDrift(normalizedEditor.zoomDrift);
       setZoomMotionBlurTuning(normalizedEditor.zoomMotionBlurTuning);
       setZoomTemporalMotionBlur(normalizedEditor.zoomTemporalMotionBlur);
       setZoomMotionBlurSampleCount(normalizedEditor.zoomMotionBlurSampleCount);
@@ -2862,6 +2875,7 @@ export default function EditorWindow() {
       shadowIntensity,
       backgroundBlur,
       zoomMotionBlur,
+      zoomDrift,
       zoomMotionBlurTuning,
       zoomTemporalMotionBlur,
       zoomMotionBlurSampleCount,
@@ -2914,6 +2928,7 @@ export default function EditorWindow() {
     shadowIntensity,
     backgroundBlur,
     zoomMotionBlur,
+    zoomDrift,
     zoomMotionBlurTuning,
     zoomTemporalMotionBlur,
     zoomMotionBlurSampleCount,
@@ -5459,6 +5474,7 @@ export default function EditorWindow() {
             shadowIntensity: effectiveShadowIntensity,
             backgroundBlur,
             zoomMotionBlur,
+            zoomDrift,
             zoomMotionBlurTuning,
             zoomTemporalMotionBlur,
             zoomMotionBlurSampleCount,
@@ -5660,6 +5676,7 @@ export default function EditorWindow() {
             shadowIntensity: effectiveShadowIntensity,
             backgroundBlur,
             zoomMotionBlur,
+            zoomDrift,
             zoomMotionBlurTuning,
             zoomTemporalMotionBlur,
             zoomMotionBlurSampleCount,
@@ -5929,6 +5946,7 @@ export default function EditorWindow() {
       shadowIntensity,
       backgroundBlur,
       zoomMotionBlur,
+      zoomDrift,
       zoomMotionBlurTuning,
       zoomTemporalMotionBlur,
       zoomMotionBlurSampleCount,
@@ -6683,6 +6701,8 @@ export default function EditorWindow() {
                     ? zoomRegions.find((z) => z.id === selectedZoomId)?.depth
                     : null
                 }
+                zoomDrift={zoomDrift}
+                onZoomDriftChange={setZoomDrift}
                 onZoomDepthChange={handleZoomDepthChange}
                 selectedZoomInstant={
                   selectedZoomId
@@ -7017,6 +7037,7 @@ export default function EditorWindow() {
                         zoomSmoothness={zoomSmoothness}
                         zoomClassicMode={zoomClassicMode}
                         zoomMotionBlur={zoomMotionBlur}
+                        zoomDrift={zoomDrift}
                         zoomMotionBlurTuning={zoomMotionBlurTuning}
                         cursorMotionBlur={cursorMotionBlur}
                         cursorClickBounce={cursorClickBounce}

--- a/apps/desktop/src/components/editor/window.tsx
+++ b/apps/desktop/src/components/editor/window.tsx
@@ -6701,6 +6701,8 @@ export default function EditorWindow() {
                     ? zoomRegions.find((z) => z.id === selectedZoomId)?.depth
                     : null
                 }
+                zoomSmoothness={zoomSmoothness}
+                onZoomSmoothnessChange={setZoomSmoothness}
                 zoomDrift={zoomDrift}
                 onZoomDriftChange={setZoomDrift}
                 onZoomDepthChange={handleZoomDepthChange}

--- a/apps/desktop/src/components/editor/window.tsx
+++ b/apps/desktop/src/components/editor/window.tsx
@@ -4089,6 +4089,18 @@ export default function EditorWindow() {
     [selectedZoomId],
   );
 
+  const handleZoomInstantChange = useCallback(
+    (instant: boolean) => {
+      if (!selectedZoomId) return;
+      setZoomRegions((prev) =>
+        prev.map((region) =>
+          region.id === selectedZoomId ? { ...region, instant } : region,
+        ),
+      );
+    },
+    [selectedZoomId],
+  );
+
   const handleZoomPresetChange = useCallback(
     (presetId: ZoomPresetId) => {
       if (!selectedZoomId) return;
@@ -6672,6 +6684,13 @@ export default function EditorWindow() {
                     : null
                 }
                 onZoomDepthChange={handleZoomDepthChange}
+                selectedZoomInstant={
+                  selectedZoomId
+                    ? (zoomRegions.find((z) => z.id === selectedZoomId)
+                        ?.instant ?? false)
+                    : false
+                }
+                onZoomInstantChange={handleZoomInstantChange}
                 selectedZoomId={selectedZoomId}
                 selectedZoomMode={
                   selectedZoomId

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -73,7 +73,8 @@
       "smooth": {
         "label": "Smooth",
         "description": "Gentler motion for presentations, keynote-style videos, and polished reveals."
-      }
+      },
+      "custom": "Custom motion. Pick a preset to start from a known feel."
     },
     "zoomInDuration": "Zoom In Duration",
     "zoomInOverlap": "Zoom In Overlap",
@@ -130,7 +131,13 @@
     "removeBackground": "Remove background",
     "classicZoomDescription": "Drop the camera spring for every zoom. Zooms still ease in — for a hard cut, turn on Instant for that zoom.",
     "zoomDrift": "Drift",
-    "zoomDriftHint": "Slow parallax while a zoom is held, so a long hold reads as a camera rather than a crop. Manual zooms only."
+    "zoomDriftHint": "Slow parallax while a zoom is held, so a long hold reads as a camera rather than a crop. Manual zooms only.",
+    "zoomSmoothness": "Camera smoothness",
+    "cameraSpringControlsHint": "Tune camera movement physics. Motion presets set these; every one stays editable here.",
+    "cameraSpringControls": "Camera Spring",
+    "cameraSpringStiffnessMultiplier": "Camera stiffness",
+    "cameraSpringDampingMultiplier": "Camera damping",
+    "cameraSpringMassMultiplier": "Camera mass"
   },
   "sections": {
     "scene": "Scene",

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "Auto",
     "modeManual": "Manual",
     "modeManualDescription": "Set a fixed focus point for this zoom",
-    "modeAutoDescription": "Camera recenters when the cursor nears the edge of the zoomed view"
+    "modeAutoDescription": "Camera recenters when the cursor nears the edge of the zoomed view",
+    "instant": "Instant",
+    "instantDescription": "Cut straight to this zoom instead of easing in. The zoom out is unaffected."
   },
   "trim": {
     "deleteRegion": "Delete Trim Region"
@@ -125,7 +127,8 @@
     "paddingBottom": "Bottom",
     "paddingLeft": "Left",
     "paddingRight": "Right",
-    "removeBackground": "Remove background"
+    "removeBackground": "Remove background",
+    "classicZoomDescription": "Drop the camera spring for every zoom. Zooms still ease in — for a hard cut, turn on Instant for that zoom."
   },
   "sections": {
     "scene": "Scene",

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -128,7 +128,9 @@
     "paddingLeft": "Left",
     "paddingRight": "Right",
     "removeBackground": "Remove background",
-    "classicZoomDescription": "Drop the camera spring for every zoom. Zooms still ease in — for a hard cut, turn on Instant for that zoom."
+    "classicZoomDescription": "Drop the camera spring for every zoom. Zooms still ease in — for a hard cut, turn on Instant for that zoom.",
+    "zoomDrift": "Drift",
+    "zoomDriftHint": "Slow parallax while a zoom is held, so a long hold reads as a camera rather than a crop. Manual zooms only."
   },
   "sections": {
     "scene": "Scene",

--- a/apps/desktop/src/i18n/locales/es/settings.json
+++ b/apps/desktop/src/i18n/locales/es/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "Auto",
     "modeManual": "Manual",
     "modeManualDescription": "Establece un punto de enfoque fijo para este zoom",
-    "modeAutoDescription": "La cámara sigue el cursor automáticamente"
+    "modeAutoDescription": "La cámara sigue el cursor automáticamente",
+    "instant": "Instantáneo",
+    "instantDescription": "Corta directamente a este zoom en lugar de entrar suavemente. El alejamiento no cambia."
   },
   "trim": {
     "deleteRegion": "Eliminar región de recorte"
@@ -100,7 +102,8 @@
     "paddingBottom": "Inferior",
     "paddingLeft": "Izquierdo",
     "paddingRight": "Derecho",
-    "removeBackground": "Quitar fondo"
+    "removeBackground": "Quitar fondo",
+    "classicZoomDescription": "Quita el resorte de cámara en todos los zooms. Los zooms siguen entrando suavemente: para un corte seco, activa Instantáneo en ese zoom."
   },
   "sections": {
     "scene": "Escena",

--- a/apps/desktop/src/i18n/locales/es/settings.json
+++ b/apps/desktop/src/i18n/locales/es/settings.json
@@ -103,7 +103,9 @@
     "paddingLeft": "Izquierdo",
     "paddingRight": "Derecho",
     "removeBackground": "Quitar fondo",
-    "classicZoomDescription": "Quita el resorte de cámara en todos los zooms. Los zooms siguen entrando suavemente: para un corte seco, activa Instantáneo en ese zoom."
+    "classicZoomDescription": "Quita el resorte de cámara en todos los zooms. Los zooms siguen entrando suavemente: para un corte seco, activa Instantáneo en ese zoom.",
+    "zoomDrift": "Deriva",
+    "zoomDriftHint": "Paralaje lento mientras se mantiene un zoom, para que una toma larga parezca una cámara y no un recorte. Solo en zooms manuales."
   },
   "sections": {
     "scene": "Escena",

--- a/apps/desktop/src/i18n/locales/es/settings.json
+++ b/apps/desktop/src/i18n/locales/es/settings.json
@@ -105,7 +105,16 @@
     "removeBackground": "Quitar fondo",
     "classicZoomDescription": "Quita el resorte de cámara en todos los zooms. Los zooms siguen entrando suavemente: para un corte seco, activa Instantáneo en ese zoom.",
     "zoomDrift": "Deriva",
-    "zoomDriftHint": "Paralaje lento mientras se mantiene un zoom, para que una toma larga parezca una cámara y no un recorte. Solo en zooms manuales."
+    "zoomDriftHint": "Paralaje lento mientras se mantiene un zoom, para que una toma larga parezca una cámara y no un recorte. Solo en zooms manuales.",
+    "zoomSmoothness": "Suavidad de cámara",
+    "cameraSpringControlsHint": "Ajusta la física del movimiento de cámara. Los ajustes de movimiento los definen, pero todos siguen siendo editables aquí.",
+    "cameraSpringControls": "Resorte de cámara",
+    "cameraSpringStiffnessMultiplier": "Rigidez de cámara",
+    "cameraSpringDampingMultiplier": "Amortiguación de cámara",
+    "cameraSpringMassMultiplier": "Masa de cámara",
+    "motionPresets": {
+      "custom": "Movimiento personalizado. Elige un ajuste para partir de una base conocida."
+    }
   },
   "sections": {
     "scene": "Escena",

--- a/apps/desktop/src/i18n/locales/fr/settings.json
+++ b/apps/desktop/src/i18n/locales/fr/settings.json
@@ -105,7 +105,16 @@
     "removeBackground": "Supprimer l’arrière-plan",
     "classicZoomDescription": "Supprime le ressort de caméra pour tous les zooms. Les zooms entrent toujours en douceur : pour une coupe franche, activez Instantané sur ce zoom.",
     "zoomDrift": "Dérive",
-    "zoomDriftHint": "Parallaxe lente pendant un zoom maintenu, pour qu'un plan long ressemble à une caméra plutôt qu'à un recadrage. Zooms manuels uniquement."
+    "zoomDriftHint": "Parallaxe lente pendant un zoom maintenu, pour qu'un plan long ressemble à une caméra plutôt qu'à un recadrage. Zooms manuels uniquement.",
+    "zoomSmoothness": "Douceur de caméra",
+    "cameraSpringControlsHint": "Réglez la physique du mouvement de caméra. Les préréglages les définissent ; tous restent modifiables ici.",
+    "cameraSpringControls": "Ressort de caméra",
+    "cameraSpringStiffnessMultiplier": "Rigidité de caméra",
+    "cameraSpringDampingMultiplier": "Amortissement de caméra",
+    "cameraSpringMassMultiplier": "Masse de caméra",
+    "motionPresets": {
+      "custom": "Mouvement personnalisé. Choisissez un préréglage pour partir d'une base connue."
+    }
   },
   "sections": {
     "scene": "Scène",

--- a/apps/desktop/src/i18n/locales/fr/settings.json
+++ b/apps/desktop/src/i18n/locales/fr/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "Automatique",
     "modeManual": "Manuel",
     "modeManualDescription": "Définir un point de focus fixe pour ce zoom",
-    "modeAutoDescription": "La caméra suit automatiquement le curseur"
+    "modeAutoDescription": "La caméra suit automatiquement le curseur",
+    "instant": "Instantané",
+    "instantDescription": "Coupe directement sur ce zoom au lieu d'y entrer en douceur. Le dézoom reste inchangé."
   },
   "trim": {
     "deleteRegion": "Supprimer la zone de découpe"
@@ -100,7 +102,8 @@
     "paddingBottom": "Bas",
     "paddingLeft": "Gauche",
     "paddingRight": "Droite",
-    "removeBackground": "Supprimer l’arrière-plan"
+    "removeBackground": "Supprimer l’arrière-plan",
+    "classicZoomDescription": "Supprime le ressort de caméra pour tous les zooms. Les zooms entrent toujours en douceur : pour une coupe franche, activez Instantané sur ce zoom."
   },
   "sections": {
     "scene": "Scène",

--- a/apps/desktop/src/i18n/locales/fr/settings.json
+++ b/apps/desktop/src/i18n/locales/fr/settings.json
@@ -103,7 +103,9 @@
     "paddingLeft": "Gauche",
     "paddingRight": "Droite",
     "removeBackground": "Supprimer l’arrière-plan",
-    "classicZoomDescription": "Supprime le ressort de caméra pour tous les zooms. Les zooms entrent toujours en douceur : pour une coupe franche, activez Instantané sur ce zoom."
+    "classicZoomDescription": "Supprime le ressort de caméra pour tous les zooms. Les zooms entrent toujours en douceur : pour une coupe franche, activez Instantané sur ce zoom.",
+    "zoomDrift": "Dérive",
+    "zoomDriftHint": "Parallaxe lente pendant un zoom maintenu, pour qu'un plan long ressemble à une caméra plutôt qu'à un recadrage. Zooms manuels uniquement."
   },
   "sections": {
     "scene": "Scène",

--- a/apps/desktop/src/i18n/locales/ko/settings.json
+++ b/apps/desktop/src/i18n/locales/ko/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "자동",
     "modeManual": "수동",
     "modeManualDescription": "이 확대에 고정 초점을 설정합니다",
-    "modeAutoDescription": "카메라가 커서를 자동으로 따라갑니다"
+    "modeAutoDescription": "카메라가 커서를 자동으로 따라갑니다",
+    "instant": "즉시",
+    "instantDescription": "부드럽게 들어가지 않고 이 줌으로 바로 컷합니다. 축소에는 영향이 없습니다."
   },
   "trim": {
     "deleteRegion": "트림 구간 삭제"
@@ -100,7 +102,8 @@
     "paddingBottom": "아래",
     "paddingLeft": "왼쪽",
     "paddingRight": "오른쪽",
-    "removeBackground": "배경 제거"
+    "removeBackground": "배경 제거",
+    "classicZoomDescription": "모든 줌에서 카메라 스프링을 끕니다. 줌은 여전히 서서히 들어갑니다 — 하드 컷을 원하면 해당 줌에서 즉시를 켜세요."
   },
   "sections": {
     "scene": "장면",

--- a/apps/desktop/src/i18n/locales/ko/settings.json
+++ b/apps/desktop/src/i18n/locales/ko/settings.json
@@ -105,7 +105,16 @@
     "removeBackground": "배경 제거",
     "classicZoomDescription": "모든 줌에서 카메라 스프링을 끕니다. 줌은 여전히 서서히 들어갑니다 — 하드 컷을 원하면 해당 줌에서 즉시를 켜세요.",
     "zoomDrift": "드리프트",
-    "zoomDriftHint": "줌을 유지하는 동안 느린 시차 이동을 넣어, 긴 장면이 잘라낸 화면이 아니라 카메라처럼 보이게 합니다. 수동 줌에만 적용됩니다."
+    "zoomDriftHint": "줌을 유지하는 동안 느린 시차 이동을 넣어, 긴 장면이 잘라낸 화면이 아니라 카메라처럼 보이게 합니다. 수동 줌에만 적용됩니다.",
+    "zoomSmoothness": "카메라 부드러움",
+    "cameraSpringControlsHint": "카메라 움직임의 물리를 조정합니다. 모션 프리셋이 설정하지만, 모든 값은 여기서 계속 편집할 수 있습니다.",
+    "cameraSpringControls": "카메라 스프링",
+    "cameraSpringStiffnessMultiplier": "카메라 강성",
+    "cameraSpringDampingMultiplier": "카메라 감쇠",
+    "cameraSpringMassMultiplier": "카메라 질량",
+    "motionPresets": {
+      "custom": "사용자 지정 모션입니다. 프리셋을 선택해 익숙한 느낌에서 시작하세요."
+    }
   },
   "sections": {
     "scene": "장면",

--- a/apps/desktop/src/i18n/locales/ko/settings.json
+++ b/apps/desktop/src/i18n/locales/ko/settings.json
@@ -103,7 +103,9 @@
     "paddingLeft": "왼쪽",
     "paddingRight": "오른쪽",
     "removeBackground": "배경 제거",
-    "classicZoomDescription": "모든 줌에서 카메라 스프링을 끕니다. 줌은 여전히 서서히 들어갑니다 — 하드 컷을 원하면 해당 줌에서 즉시를 켜세요."
+    "classicZoomDescription": "모든 줌에서 카메라 스프링을 끕니다. 줌은 여전히 서서히 들어갑니다 — 하드 컷을 원하면 해당 줌에서 즉시를 켜세요.",
+    "zoomDrift": "드리프트",
+    "zoomDriftHint": "줌을 유지하는 동안 느린 시차 이동을 넣어, 긴 장면이 잘라낸 화면이 아니라 카메라처럼 보이게 합니다. 수동 줌에만 적용됩니다."
   },
   "sections": {
     "scene": "장면",

--- a/apps/desktop/src/i18n/locales/nl/settings.json
+++ b/apps/desktop/src/i18n/locales/nl/settings.json
@@ -105,7 +105,16 @@
     "removeBackground": "Achtergrond verwijderen",
     "classicZoomDescription": "Schakel de cameraveer uit voor elke zoom. Zooms zoomen nog steeds geleidelijk in — zet Direct aan op die zoom voor een harde cut.",
     "zoomDrift": "Drift",
-    "zoomDriftHint": "Trage parallax terwijl een zoom wordt vastgehouden, zodat een lange opname als camera leest in plaats van als uitsnede. Alleen handmatige zooms."
+    "zoomDriftHint": "Trage parallax terwijl een zoom wordt vastgehouden, zodat een lange opname als camera leest in plaats van als uitsnede. Alleen handmatige zooms.",
+    "zoomSmoothness": "Camerasoepelheid",
+    "cameraSpringControlsHint": "Stel de bewegingsfysica van de camera in. Bewegingsvoorinstellingen zetten deze; alle blijven hier bewerkbaar.",
+    "cameraSpringControls": "Cameraveer",
+    "cameraSpringStiffnessMultiplier": "Camerastijfheid",
+    "cameraSpringDampingMultiplier": "Cameradamping",
+    "cameraSpringMassMultiplier": "Cameramassa",
+    "motionPresets": {
+      "custom": "Aangepaste beweging. Kies een voorinstelling om vanaf een bekend gevoel te starten."
+    }
   },
   "sections": {
     "scene": "Scène",

--- a/apps/desktop/src/i18n/locales/nl/settings.json
+++ b/apps/desktop/src/i18n/locales/nl/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "Auto",
     "modeManual": "Handmatig",
     "modeManualDescription": "Stel een vast focuspunt in voor deze zoom",
-    "modeAutoDescription": "De camera volgt de cursor automatisch"
+    "modeAutoDescription": "De camera volgt de cursor automatisch",
+    "instant": "Direct",
+    "instantDescription": "Snijd meteen naar deze zoom in plaats van geleidelijk in te zoomen. Het uitzoomen verandert niet."
   },
   "trim": {
     "deleteRegion": "Trimgebied verwijderen"
@@ -100,7 +102,8 @@
     "paddingBottom": "Onder",
     "paddingLeft": "Links",
     "paddingRight": "Rechts",
-    "removeBackground": "Achtergrond verwijderen"
+    "removeBackground": "Achtergrond verwijderen",
+    "classicZoomDescription": "Schakel de cameraveer uit voor elke zoom. Zooms zoomen nog steeds geleidelijk in — zet Direct aan op die zoom voor een harde cut."
   },
   "sections": {
     "scene": "Scène",

--- a/apps/desktop/src/i18n/locales/nl/settings.json
+++ b/apps/desktop/src/i18n/locales/nl/settings.json
@@ -103,7 +103,9 @@
     "paddingLeft": "Links",
     "paddingRight": "Rechts",
     "removeBackground": "Achtergrond verwijderen",
-    "classicZoomDescription": "Schakel de cameraveer uit voor elke zoom. Zooms zoomen nog steeds geleidelijk in — zet Direct aan op die zoom voor een harde cut."
+    "classicZoomDescription": "Schakel de cameraveer uit voor elke zoom. Zooms zoomen nog steeds geleidelijk in — zet Direct aan op die zoom voor een harde cut.",
+    "zoomDrift": "Drift",
+    "zoomDriftHint": "Trage parallax terwijl een zoom wordt vastgehouden, zodat een lange opname als camera leest in plaats van als uitsnede. Alleen handmatige zooms."
   },
   "sections": {
     "scene": "Scène",

--- a/apps/desktop/src/i18n/locales/pt-BR/settings.json
+++ b/apps/desktop/src/i18n/locales/pt-BR/settings.json
@@ -103,7 +103,9 @@
     "paddingLeft": "Esquerdo",
     "paddingRight": "Direito",
     "removeBackground": "Remover fundo",
-    "classicZoomDescription": "Remove a mola de câmera de todos os zooms. Os zooms ainda entram suavemente — para um corte seco, ative Instantâneo nesse zoom."
+    "classicZoomDescription": "Remove a mola de câmera de todos os zooms. Os zooms ainda entram suavemente — para um corte seco, ative Instantâneo nesse zoom.",
+    "zoomDrift": "Deriva",
+    "zoomDriftHint": "Paralaxe lenta enquanto um zoom é mantido, para que uma tomada longa pareça uma câmera e não um recorte. Apenas zooms manuais."
   },
   "sections": {
     "scene": "Cena",

--- a/apps/desktop/src/i18n/locales/pt-BR/settings.json
+++ b/apps/desktop/src/i18n/locales/pt-BR/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "Auto",
     "modeManual": "Manual",
     "modeManualDescription": "Defina um ponto de foco fixo para este zoom",
-    "modeAutoDescription": "A câmera segue o cursor automaticamente"
+    "modeAutoDescription": "A câmera segue o cursor automaticamente",
+    "instant": "Instantâneo",
+    "instantDescription": "Corta direto para este zoom em vez de entrar suavemente. O afastamento não muda."
   },
   "trim": {
     "deleteRegion": "Excluir região de corte"
@@ -100,7 +102,8 @@
     "paddingBottom": "Inferior",
     "paddingLeft": "Esquerdo",
     "paddingRight": "Direito",
-    "removeBackground": "Remover fundo"
+    "removeBackground": "Remover fundo",
+    "classicZoomDescription": "Remove a mola de câmera de todos os zooms. Os zooms ainda entram suavemente — para um corte seco, ative Instantâneo nesse zoom."
   },
   "sections": {
     "scene": "Cena",

--- a/apps/desktop/src/i18n/locales/pt-BR/settings.json
+++ b/apps/desktop/src/i18n/locales/pt-BR/settings.json
@@ -105,7 +105,16 @@
     "removeBackground": "Remover fundo",
     "classicZoomDescription": "Remove a mola de câmera de todos os zooms. Os zooms ainda entram suavemente — para um corte seco, ative Instantâneo nesse zoom.",
     "zoomDrift": "Deriva",
-    "zoomDriftHint": "Paralaxe lenta enquanto um zoom é mantido, para que uma tomada longa pareça uma câmera e não um recorte. Apenas zooms manuais."
+    "zoomDriftHint": "Paralaxe lenta enquanto um zoom é mantido, para que uma tomada longa pareça uma câmera e não um recorte. Apenas zooms manuais.",
+    "zoomSmoothness": "Suavidade da câmera",
+    "cameraSpringControlsHint": "Ajuste a física do movimento de câmera. As predefinições de movimento as definem; todas continuam editáveis aqui.",
+    "cameraSpringControls": "Mola de câmera",
+    "cameraSpringStiffnessMultiplier": "Rigidez da câmera",
+    "cameraSpringDampingMultiplier": "Amortecimento da câmera",
+    "cameraSpringMassMultiplier": "Massa da câmera",
+    "motionPresets": {
+      "custom": "Movimento personalizado. Escolha uma predefinição para partir de uma base conhecida."
+    }
   },
   "sections": {
     "scene": "Cena",

--- a/apps/desktop/src/i18n/locales/zh-CN/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/settings.json
@@ -120,7 +120,9 @@
     "paddingLeft": "左",
     "paddingRight": "右",
     "removeBackground": "移除背景",
-    "classicZoomDescription": "为所有缩放关闭相机弹簧。缩放仍会缓入——需要硬切时，请为该缩放开启「瞬间」。"
+    "classicZoomDescription": "为所有缩放关闭相机弹簧。缩放仍会缓入——需要硬切时，请为该缩放开启「瞬间」。",
+    "zoomDrift": "漂移",
+    "zoomDriftHint": "保持缩放时加入缓慢视差，让长镜头看起来像运镜而不是裁切。仅适用于手动缩放。"
   },
   "sections": {
     "scene": "场景",

--- a/apps/desktop/src/i18n/locales/zh-CN/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/settings.json
@@ -68,7 +68,8 @@
       "smooth": {
         "label": "平滑",
         "description": "更柔和，适合展示、发布会风格视频和更从容的镜头。"
-      }
+      },
+      "custom": "自定义运动。选择一个预设，从已知的手感开始。"
     },
     "zoomInDuration": "进入时长",
     "zoomInOverlap": "进入重叠",
@@ -122,7 +123,13 @@
     "removeBackground": "移除背景",
     "classicZoomDescription": "为所有缩放关闭相机弹簧。缩放仍会缓入——需要硬切时，请为该缩放开启「瞬间」。",
     "zoomDrift": "漂移",
-    "zoomDriftHint": "保持缩放时加入缓慢视差，让长镜头看起来像运镜而不是裁切。仅适用于手动缩放。"
+    "zoomDriftHint": "保持缩放时加入缓慢视差，让长镜头看起来像运镜而不是裁切。仅适用于手动缩放。",
+    "zoomSmoothness": "镜头平滑度",
+    "cameraSpringControlsHint": "调整镜头运动的物理参数。运动预设会设置这些值，但每一项都仍可在此编辑。",
+    "cameraSpringControls": "相机弹簧",
+    "cameraSpringStiffnessMultiplier": "相机刚度",
+    "cameraSpringDampingMultiplier": "相机阻尼",
+    "cameraSpringMassMultiplier": "相机质量"
   },
   "sections": {
     "scene": "场景",

--- a/apps/desktop/src/i18n/locales/zh-CN/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "自动",
     "modeManual": "手动",
     "modeManualDescription": "为此缩放设置固定焦点",
-    "modeAutoDescription": "镜头会自动跟随光标"
+    "modeAutoDescription": "镜头会自动跟随光标",
+    "instant": "瞬间",
+    "instantDescription": "直接切到该缩放，而不是缓入。缩小不受影响。"
   },
   "trim": {
     "deleteRegion": "删除修剪区域"
@@ -117,7 +119,8 @@
     "paddingBottom": "下",
     "paddingLeft": "左",
     "paddingRight": "右",
-    "removeBackground": "移除背景"
+    "removeBackground": "移除背景",
+    "classicZoomDescription": "为所有缩放关闭相机弹簧。缩放仍会缓入——需要硬切时，请为该缩放开启「瞬间」。"
   },
   "sections": {
     "scene": "场景",

--- a/apps/desktop/src/i18n/locales/zh-TW/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-TW/settings.json
@@ -103,7 +103,9 @@
     "paddingLeft": "左",
     "paddingRight": "右",
     "removeBackground": "移除背景",
-    "classicZoomDescription": "為所有縮放關閉相機彈簧。縮放仍會緩入——需要硬切時，請為該縮放開啟「瞬間」。"
+    "classicZoomDescription": "為所有縮放關閉相機彈簧。縮放仍會緩入——需要硬切時，請為該縮放開啟「瞬間」。",
+    "zoomDrift": "漂移",
+    "zoomDriftHint": "保持縮放時加入緩慢視差，讓長鏡頭看起來像運鏡而不是裁切。僅適用於手動縮放。"
   },
   "sections": {
     "scene": "場景",

--- a/apps/desktop/src/i18n/locales/zh-TW/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-TW/settings.json
@@ -105,7 +105,16 @@
     "removeBackground": "移除背景",
     "classicZoomDescription": "為所有縮放關閉相機彈簧。縮放仍會緩入——需要硬切時，請為該縮放開啟「瞬間」。",
     "zoomDrift": "漂移",
-    "zoomDriftHint": "保持縮放時加入緩慢視差，讓長鏡頭看起來像運鏡而不是裁切。僅適用於手動縮放。"
+    "zoomDriftHint": "保持縮放時加入緩慢視差，讓長鏡頭看起來像運鏡而不是裁切。僅適用於手動縮放。",
+    "zoomSmoothness": "鏡頭平滑度",
+    "cameraSpringControlsHint": "調整鏡頭運動的物理參數。運動預設會設定這些值，但每一項都仍可在此編輯。",
+    "cameraSpringControls": "相機彈簧",
+    "cameraSpringStiffnessMultiplier": "相機剛度",
+    "cameraSpringDampingMultiplier": "相機阻尼",
+    "cameraSpringMassMultiplier": "相機質量",
+    "motionPresets": {
+      "custom": "自訂運動。選擇一個預設，從已知的手感開始。"
+    }
   },
   "sections": {
     "scene": "場景",

--- a/apps/desktop/src/i18n/locales/zh-TW/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-TW/settings.json
@@ -6,7 +6,9 @@
     "modeAuto": "自動",
     "modeManual": "手動",
     "modeManualDescription": "為此縮放設定固定的對焦點",
-    "modeAutoDescription": "相機會自動跟隨游標"
+    "modeAutoDescription": "相機會自動跟隨游標",
+    "instant": "瞬間",
+    "instantDescription": "直接切到該縮放，而不是緩入。縮小不受影響。"
   },
   "trim": {
     "deleteRegion": "刪除修剪區域"
@@ -100,7 +102,8 @@
     "paddingBottom": "下",
     "paddingLeft": "左",
     "paddingRight": "右",
-    "removeBackground": "移除背景"
+    "removeBackground": "移除背景",
+    "classicZoomDescription": "為所有縮放關閉相機彈簧。縮放仍會緩入——需要硬切時，請為該縮放開啟「瞬間」。"
   },
   "sections": {
     "scene": "場景",

--- a/apps/desktop/src/lib/exporter/frame-renderer.ts
+++ b/apps/desktop/src/lib/exporter/frame-renderer.ts
@@ -49,7 +49,11 @@ import {
   stepSpringValue,
 } from "@/components/editor/videoPlayback/motionSmoothing";
 import { getWebcamMediaTargetTimeSeconds } from "@/components/editor/videoPlayback/webcamSync";
-import { findDominantRegion } from "@/components/editor/videoPlayback/zoomRegionUtils";
+import {
+  buildCameraMotionOptions,
+  type CameraMotionOptions,
+  findDominantRegion,
+} from "@/components/editor/videoPlayback/zoomRegionUtils";
 import {
   applyZoomTransform,
   computeFocusFromTransform,
@@ -310,6 +314,7 @@ export class FrameRenderer {
   private lastSyncedBackgroundLoopTimeSec: number | null = null;
   private cleanupBackgroundSource: (() => void) | null = null;
   private config: FrameRenderConfig;
+  private cameraMotionOptions: CameraMotionOptions;
   private animationState: AnimationState;
   private motionBlurState: MotionBlurState;
   private layoutCache: LayoutCache | null = null;
@@ -343,6 +348,9 @@ export class FrameRenderer {
 
   constructor(config: FrameRenderConfig) {
     this.config = config;
+    // Config never changes after construction, so this is built once rather
+    // than per frame.
+    this.cameraMotionOptions = buildCameraMotionOptions(config);
     this.animationState = createAnimationState();
     this.motionBlurState = createMotionBlurState();
     this.springScale = createSpringState(1);
@@ -1982,11 +1990,7 @@ export class FrameRenderer {
     const { region, strength, blendedScale, transition } = findDominantRegion(
       this.config.zoomRegions,
       timeMs,
-      {
-        connectZooms: this.config.connectZooms,
-        zoomInDurationMs: this.config.zoomInDurationMs,
-        zoomOutDurationMs: this.config.zoomOutDurationMs,
-      },
+      this.cameraMotionOptions,
     );
 
     const defaultFocus = DEFAULT_FOCUS;

--- a/apps/desktop/src/lib/exporter/frame-renderer.ts
+++ b/apps/desktop/src/lib/exporter/frame-renderer.ts
@@ -53,6 +53,7 @@ import {
   buildCameraMotionOptions,
   type CameraMotionOptions,
   findDominantRegion,
+  isInstantZoomCut,
 } from "@/components/editor/videoPlayback/zoomRegionUtils";
 import {
   applyZoomTransform,
@@ -167,6 +168,8 @@ interface AnimationState {
   progress: number;
   x: number;
   y: number;
+  /** True only on the frame an instant zoom lands. See isInstantZoomCut. */
+  instantCut: boolean;
 }
 
 type ExportRenderBackend = "webgl" | "webgpu";
@@ -269,6 +272,7 @@ function createAnimationState(): AnimationState {
     progress: 0,
     x: 0,
     y: 0,
+    instantCut: false,
   };
 }
 
@@ -1699,6 +1703,7 @@ export class FrameRenderer {
       focusY: this.animationState.focusY,
       isPlaying: true,
       motionBlurAmount: this.config.zoomMotionBlur ?? 0,
+      suppressMotionBlur: this.animationState.instantCut,
       motionBlurTuning: this.config.zoomMotionBlurTuning,
       transformOverride: {
         scale: this.animationState.appliedScale,
@@ -2075,7 +2080,9 @@ export class FrameRenderer {
     state.scale = targetScaleFactor;
     state.focusX = targetFocus.cx;
     state.focusY = targetFocus.cy;
+    const instantCut = isInstantZoomCut(region, strength, state.progress);
     state.progress = targetProgress;
+    state.instantCut = instantCut;
 
     const projectedTransform = computeZoomTransform({
       stageSize: this.layoutCache.stageSize,
@@ -2100,7 +2107,9 @@ export class FrameRenderer {
       massMultiplier: this.config.cameraSpringMassMultiplier,
     });
 
-    if (this.config.zoomClassicMode) {
+    // An instant zoom skips the spring on its landing frame, or the spring
+    // glides the cut. Only that frame — the rest of the hold springs normally.
+    if (this.config.zoomClassicMode || state.instantCut) {
       state.appliedScale = projectedTransform.scale;
       state.x = projectedTransform.x;
       state.y = projectedTransform.y;
@@ -2197,6 +2206,7 @@ export class FrameRenderer {
       motionBlurAmount: useVelocityMotionBlur
         ? (this.config.zoomMotionBlur ?? 0)
         : 0,
+      suppressMotionBlur: this.animationState.instantCut,
       motionBlurTuning: this.config.zoomMotionBlurTuning,
       transformOverride: {
         scale: this.animationState.appliedScale,

--- a/apps/desktop/src/lib/exporter/frame-renderer.ts
+++ b/apps/desktop/src/lib/exporter/frame-renderer.ts
@@ -113,6 +113,7 @@ interface FrameRenderConfig {
   shadowIntensity: number;
   backgroundBlur: number;
   zoomMotionBlur?: number;
+  zoomDrift?: number;
   zoomMotionBlurTuning?: ZoomMotionBlurTuning;
   zoomTemporalMotionBlur?: number;
   zoomMotionBlurSampleCount?: number | null;

--- a/apps/desktop/src/lib/exporter/gif-exporter.ts
+++ b/apps/desktop/src/lib/exporter/gif-exporter.ts
@@ -47,6 +47,7 @@ interface GifExporterConfig {
   shadowIntensity: number;
   backgroundBlur: number;
   zoomMotionBlur?: number;
+  zoomDrift?: number;
   zoomMotionBlurTuning?: ZoomMotionBlurTuning;
   zoomTemporalMotionBlur?: number;
   zoomMotionBlurSampleCount?: number | null;
@@ -177,6 +178,7 @@ export class GifExporter {
         shadowIntensity: this.config.shadowIntensity,
         backgroundBlur: this.config.backgroundBlur,
         zoomMotionBlur: this.config.zoomMotionBlur,
+        zoomDrift: this.config.zoomDrift,
         zoomMotionBlurTuning: this.config.zoomMotionBlurTuning,
         zoomTemporalMotionBlur: this.config.zoomTemporalMotionBlur,
         zoomMotionBlurSampleCount: this.config.zoomMotionBlurSampleCount,

--- a/apps/desktop/src/lib/exporter/modern-frame-renderer.ts
+++ b/apps/desktop/src/lib/exporter/modern-frame-renderer.ts
@@ -132,6 +132,7 @@ interface FrameRenderConfig {
   shadowIntensity: number;
   backgroundBlur: number;
   zoomMotionBlur?: number;
+  zoomDrift?: number;
   zoomMotionBlurTuning?: ZoomMotionBlurTuning;
   zoomTemporalMotionBlur?: number;
   zoomMotionBlurSampleCount?: number | null;

--- a/apps/desktop/src/lib/exporter/modern-frame-renderer.ts
+++ b/apps/desktop/src/lib/exporter/modern-frame-renderer.ts
@@ -56,7 +56,11 @@ import {
   stepSpringValue,
 } from "@/components/editor/videoPlayback/motionSmoothing";
 import { getWebcamMediaTargetTimeSeconds } from "@/components/editor/videoPlayback/webcamSync";
-import { findDominantRegion } from "@/components/editor/videoPlayback/zoomRegionUtils";
+import {
+  buildCameraMotionOptions,
+  type CameraMotionOptions,
+  findDominantRegion,
+} from "@/components/editor/videoPlayback/zoomRegionUtils";
 import {
   applyZoomTransform,
   computeFocusFromTransform,
@@ -494,6 +498,7 @@ export class FrameRenderer {
   private temporalCompositeCanvas: ExportCompositeCanvasState | null = null;
   private outputCanvasOverride: HTMLCanvasElement | null = null;
   private config: FrameRenderConfig;
+  private cameraMotionOptions: CameraMotionOptions;
   private animationState: AnimationState;
   private motionBlurState: MotionBlurState;
   private springScale: SpringState;
@@ -527,6 +532,9 @@ export class FrameRenderer {
 
   constructor(config: FrameRenderConfig) {
     this.config = config;
+    // Config never changes after construction, so this is built once rather
+    // than per frame.
+    this.cameraMotionOptions = buildCameraMotionOptions(config);
     this.animationState = createAnimationState();
     this.motionBlurState = createMotionBlurState();
     this.springScale = createSpringState(1);
@@ -3662,11 +3670,7 @@ export class FrameRenderer {
     const { region, strength, blendedScale, transition } = findDominantRegion(
       this.config.zoomRegions,
       timeMs,
-      {
-        connectZooms: this.config.connectZooms,
-        zoomInDurationMs: this.config.zoomInDurationMs,
-        zoomOutDurationMs: this.config.zoomOutDurationMs,
-      },
+      this.cameraMotionOptions,
     );
 
     let targetScaleFactor = 1;

--- a/apps/desktop/src/lib/exporter/modern-frame-renderer.ts
+++ b/apps/desktop/src/lib/exporter/modern-frame-renderer.ts
@@ -60,6 +60,7 @@ import {
   buildCameraMotionOptions,
   type CameraMotionOptions,
   findDominantRegion,
+  isInstantZoomCut,
 } from "@/components/editor/videoPlayback/zoomRegionUtils";
 import {
   applyZoomTransform,
@@ -187,6 +188,8 @@ interface AnimationState {
   progress: number;
   x: number;
   y: number;
+  /** True only on the frame an instant zoom lands. See isInstantZoomCut. */
+  instantCut: boolean;
 }
 
 interface LayoutCache {
@@ -354,6 +357,7 @@ function createAnimationState(): AnimationState {
     progress: 0,
     x: 0,
     y: 0,
+    instantCut: false,
   };
 }
 
@@ -3016,6 +3020,7 @@ export class FrameRenderer {
       motionBlurAmount: useVelocityMotionBlur
         ? (this.config.zoomMotionBlur ?? 0)
         : 0,
+      suppressMotionBlur: this.animationState.instantCut,
       motionBlurTuning: this.config.zoomMotionBlurTuning,
       transformOverride: {
         scale: this.animationState.appliedScale,
@@ -3286,6 +3291,7 @@ export class FrameRenderer {
       focusY: this.animationState.focusY,
       isPlaying: true,
       motionBlurAmount: this.config.zoomMotionBlur ?? 0,
+      suppressMotionBlur: this.animationState.instantCut,
       motionBlurTuning: this.config.zoomMotionBlurTuning,
       transformOverride: {
         scale: this.animationState.appliedScale,
@@ -3753,7 +3759,9 @@ export class FrameRenderer {
     state.scale = targetScaleFactor;
     state.focusX = targetFocus.cx;
     state.focusY = targetFocus.cy;
+    const instantCut = isInstantZoomCut(region, strength, state.progress);
     state.progress = targetProgress;
+    state.instantCut = instantCut;
 
     const projectedTransform = computeZoomTransform({
       stageSize: this.layoutCache.stageSize,
@@ -3778,7 +3786,9 @@ export class FrameRenderer {
       massMultiplier: this.config.cameraSpringMassMultiplier,
     });
 
-    if (this.config.zoomClassicMode) {
+    // An instant zoom skips the spring on its landing frame, or the spring
+    // glides the cut. Only that frame — the rest of the hold springs normally.
+    if (this.config.zoomClassicMode || state.instantCut) {
       state.appliedScale = projectedTransform.scale;
       state.x = projectedTransform.x;
       state.y = projectedTransform.y;

--- a/apps/desktop/src/lib/exporter/modern-video-exporter.ts
+++ b/apps/desktop/src/lib/exporter/modern-video-exporter.ts
@@ -107,6 +107,7 @@ interface VideoExporterConfig extends ExportConfig {
   shadowIntensity: number;
   backgroundBlur: number;
   zoomMotionBlur?: number;
+  zoomDrift?: number;
   zoomMotionBlurTuning?: ZoomMotionBlurTuning;
   zoomTemporalMotionBlur?: number;
   zoomMotionBlurSampleCount?: number | null;
@@ -562,6 +563,7 @@ export class ModernVideoExporter {
         shadowIntensity: this.config.shadowIntensity,
         backgroundBlur: this.config.backgroundBlur,
         zoomMotionBlur: this.config.zoomMotionBlur,
+        zoomDrift: this.config.zoomDrift,
         zoomMotionBlurTuning: this.config.zoomMotionBlurTuning,
         zoomTemporalMotionBlur: this.config.zoomTemporalMotionBlur,
         zoomMotionBlurSampleCount: this.config.zoomMotionBlurSampleCount,

--- a/apps/desktop/src/lib/exporter/modern-video-exporter.ts
+++ b/apps/desktop/src/lib/exporter/modern-video-exporter.ts
@@ -31,7 +31,10 @@ import {
   stepSpringValue,
 } from "@/components/editor/videoPlayback/motionSmoothing";
 import { getCursorStyleSizeMultiplier } from "@/components/editor/videoPlayback/uploadedCursorAssets";
-import { findDominantRegion } from "@/components/editor/videoPlayback/zoomRegionUtils";
+import {
+  buildCameraMotionOptions,
+  findDominantRegion,
+} from "@/components/editor/videoPlayback/zoomRegionUtils";
 import {
   computeFocusFromTransform,
   computeZoomTransform,
@@ -2145,6 +2148,7 @@ export class ModernVideoExporter {
     const springX = createSpringState(0);
     const springY = createSpringState(0);
     const zoomSpringConfig = getZoomSpringConfig(this.config.zoomSmoothness);
+    const cameraMotionOptions = buildCameraMotionOptions(this.config);
     const frameDurationMs = 1000 / Math.max(1, this.config.frameRate);
     const samples: NativeStaticLayoutZoomSample[] = [];
     let lastContentTimeMs: number | null = null;
@@ -2157,9 +2161,7 @@ export class ModernVideoExporter {
       const { region, strength, blendedScale, transition } = findDominantRegion(
         zoomRegions,
         timeMs,
-        {
-          connectZooms: this.config.connectZooms,
-        },
+        cameraMotionOptions,
       );
 
       let targetScale = 1;

--- a/apps/desktop/src/lib/exporter/video-exporter.ts
+++ b/apps/desktop/src/lib/exporter/video-exporter.ts
@@ -57,6 +57,7 @@ interface VideoExporterConfig extends ExportConfig {
   shadowIntensity: number;
   backgroundBlur: number;
   zoomMotionBlur?: number;
+  zoomDrift?: number;
   zoomMotionBlurTuning?: ZoomMotionBlurTuning;
   zoomTemporalMotionBlur?: number;
   zoomMotionBlurSampleCount?: number | null;
@@ -230,6 +231,7 @@ export class VideoExporter {
         shadowIntensity: this.config.shadowIntensity,
         backgroundBlur: this.config.backgroundBlur,
         zoomMotionBlur: this.config.zoomMotionBlur,
+        zoomDrift: this.config.zoomDrift,
         zoomMotionBlurTuning: this.config.zoomMotionBlurTuning,
         zoomTemporalMotionBlur: this.config.zoomTemporalMotionBlur,
         zoomMotionBlurSampleCount: this.config.zoomMotionBlurSampleCount,

--- a/apps/desktop/src/types/editor.ts
+++ b/apps/desktop/src/types/editor.ts
@@ -175,6 +175,8 @@ export const DEFAULT_CURSOR_CLICK_BOUNCE_DURATION = 350;
 export const DEFAULT_CURSOR_SWAY = 0.25;
 export const DEFAULT_ZOOM_SMOOTHNESS = 0.5;
 export const DEFAULT_ZOOM_MOTION_BLUR = 0.35;
+/** Slow parallax while a zoom is held. Off by default — see #24. */
+export const DEFAULT_ZOOM_DRIFT = 0;
 export interface ZoomMotionBlurTuning {
   panVelocityThreshold: number;
   zoomVelocityThreshold: number;

--- a/apps/desktop/src/types/editor.ts
+++ b/apps/desktop/src/types/editor.ts
@@ -22,6 +22,12 @@ export interface ZoomRegion {
   enabled?: boolean;
   presetId?: ZoomPresetId;
   endFocus?: ZoomFocus;
+  /**
+   * Land at full depth on the region's start frame instead of easing in, for
+   * cutting to a detail on a beat. Orthogonal to Classic Animation, which
+   * bypasses the camera spring but keeps the easing ramp.
+   */
+  instant?: boolean;
 }
 
 export interface CursorTelemetryPoint {

--- a/apps/desktop/src/types/editor.ts
+++ b/apps/desktop/src/types/editor.ts
@@ -197,9 +197,14 @@ export const DEFAULT_ZOOM_MOTION_BLUR_TUNING: ZoomMotionBlurTuning = {
   zoomSafeZoneRadiusPx: 6,
 };
 export const DEFAULT_ZOOM_IN_DURATION_MS = 1522.575;
-export const DEFAULT_ZOOM_IN_OVERLAP_MS = 500;
+// Realigned 2026-07-28 (#30) from 500 to the value actually in force —
+// zoomInOverlapMs was stored and persisted but never read, so the module
+// constant it should have matched is the true shipped behaviour.
+export const DEFAULT_ZOOM_IN_OVERLAP_MS = 1000;
 export const DEFAULT_ZOOM_OUT_DURATION_MS = 1015.05;
-export const DEFAULT_CONNECTED_ZOOM_GAP_MS = 1500;
+// Realigned 2026-07-28 (#30) from 1500 to the value actually in force. See
+// DEFAULT_ZOOM_IN_OVERLAP_MS above.
+export const DEFAULT_CONNECTED_ZOOM_GAP_MS = 1350;
 export const DEFAULT_CONNECTED_ZOOM_DURATION_MS = 1000;
 export const DEFAULT_ZOOM_IN_EASING: ZoomTransitionEasing = "quiro";
 export const DEFAULT_ZOOM_OUT_EASING: ZoomTransitionEasing = "quiro";

--- a/docs/adr/0001-configurable-first-over-opinionated-presets.md
+++ b/docs/adr/0001-configurable-first-over-opinionated-presets.md
@@ -1,0 +1,62 @@
+# 0001 — Configurable-first over opinionated presets
+
+Status: accepted, 2026-07-26 (roadmap D2)
+
+## Context
+
+A common shape for creative tools facing a novice/power-user split is to hide
+depth behind a Simple/Pro mode toggle, or to replace deep controls with a small
+set of opinionated presets and demote the raw parameters to an "advanced"
+drawer. Quiro has real depth to hide: `cursorSpringStiffnessMultiplier` and
+its siblings, six zoom depths, per-region easing, drift strength, and so on.
+
+The pressure to simplify comes from a real problem — novices don't want to
+learn a spring-physics vocabulary. But two different audiences were being
+treated as one design question: *how does a novice get a good result* and
+*where does the power-user control live*.
+
+## Decision
+
+Deep control stays the primary UI, permanently. Presets — including the
+camera/cursor motion presets and the Phase 2 named "looks" — are starting
+points a user can move away from, never the only way to reach a value. No
+Simple/Pro toggle; no controls demoted to an advanced drawer.
+
+**How this is enforced, not just intended:** as of the Phase 1 motion-preset
+work, presets are implemented against a `CursorMotionPresetHandlers` map keyed
+by every field the preset writes (`cursor-motion-presets.ts`). Adding a field
+to a preset's value shape is a compile error until a handler — i.e. a visible,
+editable control — exists for it. A preset literally cannot ship a field the
+panel doesn't expose.
+
+This also settled a real incident: `normalizeProjectEditor` used to resolve
+the closest matching preset on project load and overwrite ten stored fields
+with that preset's values, so a user's custom tuning silently reverted to the
+nearest preset on reopen. That directly violated this ADR — a preset was
+functioning as a replacement, not a starting point — and was fixed by keeping
+the user's stored values and only falling back to preset/default values for
+fields that are genuinely absent.
+
+## Consequences
+
+- Beginner accessibility cannot come from simplifying the panel. It has to
+  come from somewhere else — the conversational agent (see the sibling
+  decision on the agent as the novice surface, in `docs/product-roadmap.md`
+  D3), which moves the same sliders a power user would, rather than a
+  parallel simplified UI.
+- Every preset and every future "look" (Phase 2) must be auditable field by
+  field against the panel. A preset that sets something the panel can't show
+  is a bug, not a feature.
+- New settings-panel work should default to a visible control, not a
+  presets-only value. If a value is genuinely not meant to be user-facing yet,
+  it should not be in a preset either — see the `zoomInOverlapMs` /
+  `connectedZoomGapMs` / `connectedZoomDurationMs` case, which stayed
+  unexposed and consequently silently inert (issue #30).
+- A stale memory once told a session to build the *opposite* of this
+  decision (an opinionated-presets-first design), and it was acted on before
+  being caught. This document is the durable fix for that failure mode.
+
+## Related
+
+- `docs/product-roadmap.md` — D2, D3, D4
+- `apps/desktop/src/components/editor/utils/cursor-motion-presets.ts`

--- a/docs/adr/0002-brandkit-separate-from-looks.md
+++ b/docs/adr/0002-brandkit-separate-from-looks.md
@@ -1,0 +1,63 @@
+# 0002 — BrandKit is a separate persisted layer, never a field inside a Look
+
+Status: accepted, 2026-07-26 (roadmap D12) · not yet implemented (Phase 2)
+
+## Context
+
+Phase 2 introduces `Look` — a plain serializable subset of `ProjectEditorState`
+representing a curated or user-saved visual/motion preset — and, separately,
+brand identity (logo, colors, fonts) that a user wants applied across their
+exports. The two are easy to conflate: both are "settings that get applied to
+a project," and a naive design embeds brand fields directly inside each Look.
+
+## Decision
+
+Brand identity lives in its own persisted structure, `BrandKit`, stored in
+`<userData>` — outside and independent of any Look. A Look never carries
+logo/color/font fields directly; where it needs to reference brand identity
+(e.g. "use the brand accent color"), it references brand *tokens*, not values.
+
+**Structural rule, held firmly:** a user has *one* brand and *many* Looks.
+
+## Rationale
+
+A user's brand does not change when they switch visual styles. If brand
+fields were embedded per-Look:
+
+- Switching Looks would wipe branding, since each Look would carry its own
+  (or no) copy of the logo/colors/fonts.
+- Every new Look — built-in or user-saved — would need brand data re-entered,
+  turning an eight-built-in-Looks feature into eight opportunities to forget
+  branding.
+- There would be no single source of truth for "what is this user's brand,"
+  making a future "apply my brand consistently" agent tool (or even a manual
+  "update my logo everywhere" action) require rewriting every stored Look.
+
+The moat here is the taste embedded in the built-in Looks, not the save/load
+mechanism around them. Eight Looks that feel genuinely expensive beat infinite
+save slots, and none of that taste is compromised by keeping brand identity
+external.
+
+## Consequences
+
+- `Look` stays a plain serializable subset of `ProjectEditorState` with no
+  brand fields, which is also what keeps it costlessly shareable as a file
+  later (deferred, not built) — a Look file that referenced local brand
+  tokens by value would leak someone else's branding into it, or reference
+  tokens the recipient doesn't have.
+- The Look-application code path (settings panel, and later the `apply_look`
+  agent tool in Phase 3) must resolve brand tokens against the current
+  `BrandKit` at apply time, not read them off the Look.
+- `BrandKit` needs its own persistence, its own settings-panel surface, and
+  its own default-state question (a project with no configured brand) — none
+  of which exists yet. This ADR fixes the *shape* of that future work, not
+  its implementation.
+- A Look picker (Phase 2) can safely present Looks without also presenting
+  branding controls — they are orthogonal UI, not layered.
+
+## Related
+
+- `docs/product-roadmap.md` — D12, Phase 2 checklist
+- ADR 0001 (configurable-first) — a Look is a *starting point* users can move
+  away from, same as any preset; BrandKit similarly is not meant to be a
+  one-time embedded snapshot, it stays live and editable.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -203,7 +203,13 @@ changeable.
 
 ### Phase 1 — Motion quality *(the moat)*
 
-- [ ] **Clip transitions** — crossfade + fade-through-black, minimum-duration floor. Confirmed absent from `types/editor.ts` and `timeline/`.
+- ~~**Clip transitions**~~ — **dropped 2026-07-28.** Built and removed the same day.
+      A crossfade needs two source timestamps in one output frame, which neither
+      render path can produce: preview has a single video element, and export is a
+      single forward decode handing one frame per output frame to the renderer.
+      Supporting it means a second frame source on both paths. On seeing it in the
+      app the feature was judged not worth that, and not wanted in the product for
+      now. Motion quality is the moat; transitions are packaging.
 - [ ] **Glide/drift while zoomed** — slow parallax so a held zoom reads as camera work, not a static crop
 - [ ] **Instant-zoom option** — bypass easing for hard cuts
 - [ ] **Camera/zoom motion presets** — extend the proven `cursor-motion-presets.ts` + `MotionPresetCards` pattern

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -208,7 +208,9 @@ changeable.
 - [ ] **Instant-zoom option** — bypass easing for hard cuts
 - [ ] **Camera/zoom motion presets** — extend the proven `cursor-motion-presets.ts` + `MotionPresetCards` pattern
 - [ ] **Spring/easing tuning sweep** — the actual taste work; iterate until *untouched* output looks expensive
-- [ ] **`edgeSnapFocus` tuning pass** — already exists (`videoPlayback/focusUtils.ts:141`); validate across all 6 zoom depths
+- [x] **Edge-snap validation** — `edgeSnapFocus` turned out to be dead code and was removed; the live
+      behaviour is `recenterFocusWhenCursorLeavesSafeZone` in `videoPlayback/cursorFollowCamera.ts`,
+      now verified uniform across all 6 zoom depths. No behaviour changed.
 - [ ] **`motionSmoothing.ts` audit** — verify it earns its place
 
 ### Phase 2 — Looks & Brand Kit *(packaging)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
     },
     "apps/desktop": {
       "name": "@quiro/desktop",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.105.0",


### PR DESCRIPTION
## Summary

Nine commits implementing the camera-motion half of Phase 1 (#17: motion quality). Clip transitions were built and removed the same day — see below.

- **#18** — `buildCameraMotionOptions`, the single seam every camera-timing consumer goes through (preview ticker, both frame renderers, native static-layout precompute). Fixes a live preview/export divergence found on the way: the GPU export path was silently ignoring custom zoom durations.
- **#22** — The five easing curves (`quiro`/`glide`/`smooth`/`snappy`/`linear`) now actually take effect. They were fully plumbed through persistence, preferences and every exporter config, but nothing read them. `quiro`/`glide` are pinned bit-identical to the previous hardcoded curves via regression test, so untouched projects are unaffected.
- **#23** — Instant zoom: land at full depth on a region's start frame instead of easing in, for cutting on a beat. Required bypassing the camera spring on the landing frame specifically (not just the easing ramp) — the first attempt didn't actually work.
- **#24** — Slow drift while a zoom is held, so a static hold reads as camera work rather than a crop. Off by default; suppressed during cursor-follow and during the zoom-in ramp.
- **#27** — Motion presets (Focused/Smooth) now cover camera smoothness and spring multipliers, not just cursor behaviour. Also fixes a **shipped data-loss bug**: `normalizeProjectEditor` was overwriting ten stored fields with a matched preset's values on every project load, so custom tuning silently reverted to Focused on reopen.
- **#20** — Validated the *live* edge-snap camera behaviour across all six zoom depths (the ticket's original target, `edgeSnapFocus`, turned out to be dead code and was removed).
- **#28** — Audited the spring overshoot-clamp; confirmed it still earns its place under a reversing target. No production change.
- **#21** — `npm run compare:camera-tuning`, a dev harness for #29 (the tuning sweep) to render candidate values side-by-side against current defaults.

**Clip transitions (#19/#25/#26) were built, seen in the editor, and removed same-day.** A crossfade needs two source timestamps composited into one output frame; neither render path can produce that without a second frame source on both paths. Judged not worth the cost right now. Reasoning is in `docs/product-roadmap.md` and the closed issues; the removed code is preserved on `backup/clip-transitions` if revisited.

## Test plan

- [x] `npm run typecheck`, `npm run lint` (`--max-warnings 0`), `npm run test:unit` — all green, 317 tests
- [x] Code-reviewed per commit (standards + spec axes), findings fixed inline
- [ ] Manually verified against an exported file (preview only, verified working, per user)
- [ ] #29 tuning sweep — deliberately out of scope for this PR, unblocked once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)